### PR TITLE
Add FriendlyElec NanoPi-R6C platform

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -33,6 +33,7 @@ jobs:
           - r58x
           - r58-mini
           - edge2
+          - nanopi-r6c
           - nanopi-r6s
           - nanopc-t6
           - blade3

--- a/README.md
+++ b/README.md
@@ -13,6 +13,8 @@ This repository contains an UEFI firmware implementation based on EDK2 for vario
 - [Mekotronics R58 Mini](https://www.mekotronics.com/h-pd-76.html)
 - [Khadas Edge2](https://www.khadas.com/edge2)
 - [FriendlyELEC NanoPC T6](https://wiki.friendlyelec.com/wiki/index.php/NanoPC-T6)
+- [FriendlyELEC NanoPi R6C](https://wiki.friendlyelec.com/wiki/index.php/NanoPi_R6C)
+- [FriendlyELEC NanoPi R6S](https://wiki.friendlyelec.com/wiki/index.php/NanoPi_R6S)
 
 ## Supported peripherals
 Applicable to all platforms unless otherwise noted.

--- a/configs/nanopi-r6c.conf
+++ b/configs/nanopi-r6c.conf
@@ -1,0 +1,3 @@
+DSC_FILE=edk2-rockchip/Platform/FriendlyElec/NanoPi-R6C/NanoPi-R6C.dsc
+PLATFORM_NAME=NanoPi-R6C
+SOC=RK3588

--- a/edk2-rockchip/Platform/FriendlyElec/NanoPi-R6C/AcpiTables/AcpiTables.inf
+++ b/edk2-rockchip/Platform/FriendlyElec/NanoPi-R6C/AcpiTables/AcpiTables.inf
@@ -1,0 +1,71 @@
+#/** @file
+#
+#  ACPI table data and ASL sources required to boot the platform.
+#
+#  Copyright (c) 2019-2021, ARM Limited. All rights reserved.
+#  Copyright (c) Microsoft Corporation. All rights reserved.
+#
+#  SPDX-License-Identifier: BSD-2-Clause-Patent
+#
+#**/
+
+[Defines]
+  INF_VERSION                    = 0x0001001A
+  BASE_NAME                      = AcpiTables
+  FILE_GUID                      = 7E374E25-8E01-4FEE-87F2-390C23C606CD
+  MODULE_TYPE                    = USER_DEFINED
+  VERSION_STRING                 = 1.0
+  RK_COMMON_ACPI_DIR             = Silicon/Rockchip/RK3588/AcpiTables
+
+#
+# The following information is for reference only and not required by the build tools.
+#
+#  VALID_ARCHITECTURES           = AARCH64
+#
+
+[Sources]
+  Dsdt.asl
+  $(RK_COMMON_ACPI_DIR)/Madt.aslc
+  $(RK_COMMON_ACPI_DIR)/Fadt.aslc
+  $(RK_COMMON_ACPI_DIR)/Gtdt.aslc
+  $(RK_COMMON_ACPI_DIR)/Spcr.aslc
+  $(RK_COMMON_ACPI_DIR)/Mcfg.aslc
+  $(RK_COMMON_ACPI_DIR)/Dbg2.aslc
+  $(RK_COMMON_ACPI_DIR)/Pcie3x4.asl
+  $(RK_COMMON_ACPI_DIR)/Pcie3x2.asl
+  $(RK_COMMON_ACPI_DIR)/Pcie2x1l0.asl
+  $(RK_COMMON_ACPI_DIR)/Pcie2x1l1.asl
+  $(RK_COMMON_ACPI_DIR)/Pcie2x1l2.asl
+  $(RK_COMMON_ACPI_DIR)/Sata0.asl
+  $(RK_COMMON_ACPI_DIR)/Sata1.asl
+  $(RK_COMMON_ACPI_DIR)/Sata2.asl
+
+[Packages]
+  ArmPkg/ArmPkg.dec
+  ArmPlatformPkg/ArmPlatformPkg.dec
+  EmbeddedPkg/EmbeddedPkg.dec
+  MdeModulePkg/MdeModulePkg.dec
+  MdePkg/MdePkg.dec
+  Silicon/Rockchip/RockchipPkg.dec
+  Platform/Rockchip/RK3588/RK3588.dec
+
+[FixedPcd]
+  gArmTokenSpaceGuid.PcdArmArchTimerIntrNum
+  gArmTokenSpaceGuid.PcdArmArchTimerHypIntrNum
+  gArmTokenSpaceGuid.PcdArmArchTimerSecIntrNum
+  gArmTokenSpaceGuid.PcdArmArchTimerVirtIntrNum
+  gArmTokenSpaceGuid.PcdGicInterruptInterfaceBase
+  gArmTokenSpaceGuid.PcdGicDistributorBase
+  gArmTokenSpaceGuid.PcdGicRedistributorsBase
+  gRockchipTokenSpaceGuid.PcdPcieRootPort3x4CfgBaseAddress
+  gRockchipTokenSpaceGuid.PcdPcieRootPort3x4ApbBaseAddress
+  gRockchipTokenSpaceGuid.PcdPcieRootPort3x4DbiBaseAddress
+  gRockchipTokenSpaceGuid.PcdPcieRootPort3x4CfgBaseAddress
+  gRockchipTokenSpaceGuid.PcdPcieRootPort3x4CfgSize
+  gRockchipTokenSpaceGuid.PcdPcieRootPort3x4IoBaseAddress
+  gRockchipTokenSpaceGuid.PcdPcieRootPort3x4IoSize
+  gRockchipTokenSpaceGuid.PcdPcieRootPort3x4MemBaseAddress
+  gRockchipTokenSpaceGuid.PcdPcieRootPort3x4MemSize
+  gRockchipTokenSpaceGuid.PcdPcieRootPort3x4MemBaseAddress64
+  gRockchipTokenSpaceGuid.PcdPcieRootPort3x4MemSize64
+  gEfiMdeModulePkgTokenSpaceGuid.PcdSerialRegisterBase

--- a/edk2-rockchip/Platform/FriendlyElec/NanoPi-R6C/AcpiTables/Dsdt.asl
+++ b/edk2-rockchip/Platform/FriendlyElec/NanoPi-R6C/AcpiTables/Dsdt.asl
@@ -1,0 +1,36 @@
+/** @file
+ *
+ *  Differentiated System Definition Table (DSDT)
+ *
+ *  Copyright (c) 2020, Pete Batard <pete@akeo.ie>
+ *  Copyright (c) 2018-2020, Andrey Warkentin <andrey.warkentin@gmail.com>
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Copyright (c) 2021, ARM Limited. All rights reserved.
+ *
+ *  SPDX-License-Identifier: BSD-2-Clause-Patent
+ *
+ **/
+
+#include "AcpiTables.h"
+
+DefinitionBlock ("Dsdt.aml", "DSDT", 2, "RKCP", "RK3588S", 2)
+{
+  Scope (\_SB_)
+  {
+    include ("Cpu.asl")
+
+    include ("Emmc.asl")
+    include ("Sdhc.asl")
+    include ("Gmac.asl")
+    //include ("Gpio.asl")
+    //include ("I2c.asl")
+    include ("Uart.asl")
+    //include ("Spi.asl")
+
+    // won't work on Windows, will trigger bugcheck by usbehci
+    //include ("Usb2Host.asl")
+
+    include ("Usb3Host0.asl")
+    include ("Usb3Host1.asl")
+  }
+}

--- a/edk2-rockchip/Platform/FriendlyElec/NanoPi-R6C/Library/RockchipPlatformLib/RockchipPlatformLib.c
+++ b/edk2-rockchip/Platform/FriendlyElec/NanoPi-R6C/Library/RockchipPlatformLib/RockchipPlatformLib.c
@@ -1,0 +1,306 @@
+/** @file
+*
+*  Copyright (c) 2021, Rockchip Limited. All rights reserved.
+*
+*  SPDX-License-Identifier: BSD-2-Clause-Patent
+*
+**/
+#include <Base.h>
+#include <Library/DebugLib.h>
+#include <Library/IoLib.h>
+#include <Library/GpioLib.h>
+#include <Library/RK806.h>
+#include <Library/Rk3588Pcie.h>
+#include <Soc.h>
+
+static struct regulator_init_data rk806_init_data[] = {
+  /* Master PMIC */
+  RK8XX_VOLTAGE_INIT(MASTER_BUCK1, 750000),
+  RK8XX_VOLTAGE_INIT(MASTER_BUCK3, 750000),
+  RK8XX_VOLTAGE_INIT(MASTER_BUCK4, 750000),
+  RK8XX_VOLTAGE_INIT(MASTER_BUCK5, 850000),
+  //RK8XX_VOLTAGE_INIT(MASTER_BUCK6, 750000),
+  RK8XX_VOLTAGE_INIT(MASTER_BUCK7, 2000000),
+  RK8XX_VOLTAGE_INIT(MASTER_BUCK8, 3300000),
+  RK8XX_VOLTAGE_INIT(MASTER_BUCK10, 1800000),
+
+  RK8XX_VOLTAGE_INIT(MASTER_NLDO1, 750000),
+  RK8XX_VOLTAGE_INIT(MASTER_NLDO2, 850000),
+  RK8XX_VOLTAGE_INIT(MASTER_NLDO3, 750000),
+  RK8XX_VOLTAGE_INIT(MASTER_NLDO4, 850000),
+  RK8XX_VOLTAGE_INIT(MASTER_NLDO5, 750000),
+
+  RK8XX_VOLTAGE_INIT(MASTER_PLDO1, 1800000),
+  RK8XX_VOLTAGE_INIT(MASTER_PLDO2, 1800000),
+  RK8XX_VOLTAGE_INIT(MASTER_PLDO3, 1200000),
+  RK8XX_VOLTAGE_INIT(MASTER_PLDO4, 3300000),
+  RK8XX_VOLTAGE_INIT(MASTER_PLDO5, 3300000),
+  RK8XX_VOLTAGE_INIT(MASTER_PLDO6, 1800000),
+  /* No dual PMICs on this platform */
+};
+
+VOID
+EFIAPI
+DwEmmcDxeIoMux (
+  VOID
+  )
+{
+  /* sdmmc0 iomux (microSD socket) */
+  BUS_IOC->GPIO4D_IOMUX_SEL_L = (0xFFFFUL << 16) | (0x1111); //SDMMC_D0,SDMMC_D1,SDMMC_D2,SDMMC_D3
+  BUS_IOC->GPIO4D_IOMUX_SEL_H = (0x00FFUL << 16) | (0x0011); //SDMMC_CLK,SDMMC_CMD
+  PMU1_IOC->GPIO0A_IOMUX_SEL_H = (0x000FUL << 16) | (0x0001); //SDMMC_DET
+}
+
+VOID
+EFIAPI
+SdhciEmmcDxeIoMux (
+  VOID
+  )
+{
+  /* sdhci0 iomux (eMMC socket) */
+  BUS_IOC->GPIO2A_IOMUX_SEL_L = (0xFFFFUL << 16) | (0x1111); //EMMC_CMD,EMMC_CLKOUT,EMMC_DATASTROBE,EMMC_RSTN
+  BUS_IOC->GPIO2D_IOMUX_SEL_L = (0xFFFFUL << 16) | (0x1111); //EMMC_D0,EMMC_D1,EMMC_D2,EMMC_D3
+  BUS_IOC->GPIO2D_IOMUX_SEL_H = (0xFFFFUL << 16) | (0x1111); //EMMC_D4,EMMC_D5,EMMC_D6,EMMC_D7
+}
+
+#define NS_CRU_BASE         0xFD7C0000
+#define CRU_CLKSEL_CON59    0x03EC
+#define CRU_CLKSEL_CON78    0x0438
+
+VOID
+EFIAPI
+Rk806SpiIomux (
+  VOID
+  )
+{
+  /* io mux */
+  //BUS_IOC->GPIO1A_IOMUX_SEL_H = (0xFFFFUL << 16) | 0x8888;
+  //BUS_IOC->GPIO1B_IOMUX_SEL_L = (0x000FUL << 16) | 0x0008;
+  PMU1_IOC->GPIO0A_IOMUX_SEL_H = (0x0FF0UL << 16) | 0x0110;
+  PMU1_IOC->GPIO0B_IOMUX_SEL_L = (0xF0FFUL << 16) | 0x1011;
+  MmioWrite32(NS_CRU_BASE + CRU_CLKSEL_CON59, (0x00C0UL << 16) | 0x0080);
+}
+
+VOID
+EFIAPI
+Rk806Configure (
+  VOID
+  )
+{
+  UINTN RegCfgIndex;
+
+  RK806Init();
+
+  for (RegCfgIndex = 0; RegCfgIndex < ARRAY_SIZE(rk806_init_data); RegCfgIndex++)
+    RK806RegulatorInit(rk806_init_data[RegCfgIndex]);
+}
+
+VOID
+EFIAPI
+SetCPULittleVoltage (
+  IN UINT32 Microvolts
+  )
+{
+  struct regulator_init_data Rk806CpuLittleSupply =
+        RK8XX_VOLTAGE_INIT(MASTER_BUCK2, Microvolts);
+
+  RK806RegulatorInit(Rk806CpuLittleSupply);
+}
+
+VOID
+EFIAPI
+NorFspiIomux (
+  VOID
+  )
+{
+  /* io mux */
+  /* Do not override, set by earlier boot stages. */
+}
+
+VOID
+EFIAPI
+GmacIomux (
+   UINT32 id
+  )
+{
+  switch (id) {
+  case 0:
+    /* gmac0 iomux from Radxa Rock-5A */
+#if 0
+    BUS_IOC->GPIO2A_IOMUX_SEL_H = (0xFF00UL << 16) | 0x1100;
+    BUS_IOC->GPIO2B_IOMUX_SEL_L = (0xFFFFUL << 16) | 0x1111;
+    BUS_IOC->GPIO2B_IOMUX_SEL_H = (0xFF00UL << 16) | 0x1100;
+    BUS_IOC->GPIO2C_IOMUX_SEL_L = (0xFFFFUL << 16) | 0x1111;
+    BUS_IOC->GPIO4C_IOMUX_SEL_L = (0x0F00UL << 16) | 0x0100;
+    BUS_IOC->GPIO4C_IOMUX_SEL_H = (0x00FFUL << 16) | 0x0011;
+#endif
+    break;
+  case 1:
+    /* gmac1 iomux */
+    break;
+  default:
+    break;
+  }
+}
+
+VOID
+EFIAPI
+NorFspiEnableClock (
+  UINT32 *CruBase
+  )
+{
+  UINTN BaseAddr = (UINTN) CruBase;
+
+  MmioWrite32(BaseAddr + 0x087C, 0x0E000000);
+}
+
+VOID
+EFIAPI
+I2cIomux (
+   UINT32 id
+  )
+{
+  switch (id) {
+  case 0:
+    /* io mux M2 */
+    PMU2_IOC->GPIO0D_IOMUX_SEL_L = (0x0F00UL << 16) | 0x0300;
+    PMU2_IOC->GPIO0D_IOMUX_SEL_L = (0x00F0UL << 16) | 0x0030;
+    break;
+  case 1:
+    /* io mux */
+    //BUS_IOC->GPIO0B_IOMUX_SEL_H = (0x0FF0UL << 16) | 0x0990;
+    //PMU2_IOC->GPIO0B_IOMUX_SEL_H = (0x0FF0UL << 16) | 0x0880;
+    break;
+  case 2:
+    /* io mux */
+    BUS_IOC->GPIO0B_IOMUX_SEL_H = (0xF000UL << 16) | 0x9000;
+    BUS_IOC->GPIO0C_IOMUX_SEL_L = (0x000FUL << 16) | 0x0009;
+    PMU2_IOC->GPIO0B_IOMUX_SEL_H = (0xF000UL << 16) | 0x8000;
+    PMU2_IOC->GPIO0C_IOMUX_SEL_L = (0x000FUL << 16) | 0x0008;
+    break;
+  case 3:
+    break;
+  case 4:
+    break;
+  case 5:
+    break;
+  default:
+    break;
+  }
+}
+
+VOID
+EFIAPI
+UsbPortPowerEnable (
+  VOID
+  )
+{
+  DEBUG((EFI_D_WARN, "UsbPortPowerEnable called\n"));
+  /* Set GPIO4 PB5 (USB_HOST_PWREN) output high to power USB ports */
+  GpioPinWrite (4, GPIO_PIN_PB5, TRUE);
+  GpioPinSetDirection (4, GPIO_PIN_PB5, GPIO_PIN_OUTPUT);
+
+  /* Set GPIO1 PD2 (TYPEC5V_PWREN) output high to power the type-c port */
+  GpioPinWrite (1, GPIO_PIN_PD2, TRUE);
+  GpioPinSetDirection (1, GPIO_PIN_PD2, GPIO_PIN_OUTPUT);
+
+  // DEBUG((EFI_D_WARN, "Trying to enable on-board LED WAN\n"));
+  // GpioPinWrite (1, GPIO_PIN_PC2, TRUE);
+  // GpioPinSetDirection (1, GPIO_PIN_PC2, GPIO_PIN_OUTPUT);
+
+  // DEBUG((EFI_D_WARN, "Trying to enable on-board LED LAN\n"));
+  // GpioPinWrite (1, GPIO_PIN_PC3, TRUE);
+  // GpioPinSetDirection (1, GPIO_PIN_PC3, GPIO_PIN_OUTPUT);
+
+  // DEBUG((EFI_D_WARN, "Trying to enable on-board LED1\n"));
+  // GpioPinWrite (1, GPIO_PIN_PC4, TRUE);
+  // GpioPinSetDirection (1, GPIO_PIN_PC4, GPIO_PIN_OUTPUT);
+}
+
+VOID
+EFIAPI
+Usb2PhyResume (
+  VOID
+  )
+{
+  MmioWrite32(0xfd5d0008, 0x20000000);
+  MmioWrite32(0xfd5d4008, 0x20000000);
+  MmioWrite32(0xfd5d8008, 0x20000000);
+  MmioWrite32(0xfd5dc008, 0x20000000);
+  MmioWrite32(0xfd7f0a10, 0x07000700);
+  MmioWrite32(0xfd7f0a10, 0x07000000);
+}
+
+VOID
+EFIAPI
+UsbDpPhyEnable (
+  VOID
+  )
+{
+  /* enable rx_lfps_en & usbdp_low_pwrn */
+  MmioWrite32(0xfd5c8004, 0x60006000);
+  MmioWrite32(0xfd5cc004, 0x60006000);
+
+  /* remove rx-termination, we don't support SS yet */
+  MmioWrite32 (0xfd5c800c, 0x00030001);
+  MmioWrite32 (0xfd5cc00c, 0x00030001);
+}
+
+VOID
+EFIAPI
+PcieIoInit (
+  UINT32 Segment
+  )
+{
+  /* Set reset and power IO to gpio output mode */
+  switch(Segment) {
+    case PCIE_SEGMENT_PCIE20L1: // RTL8152BG
+      // GPIO1_A7_u - PCIE20x1_1_PERSTn_M2
+      GpioPinSetDirection (1, GPIO_PIN_PA7, GPIO_PIN_OUTPUT);
+      break;
+    case PCIE_SEGMENT_PCIE20L2: // M.2 SSD
+      // GPIO3_D1_d - PCIE20X1_2_PERSTN_M0
+      GpioPinSetDirection (3, GPIO_PIN_PD1, GPIO_PIN_OUTPUT);
+      break;
+    default:
+      break;
+  }
+}
+
+VOID
+EFIAPI
+PciePowerEn (
+  UINT32 Segment,
+  BOOLEAN Enable
+  )
+{
+  /* nothing to power on */
+}
+
+VOID
+EFIAPI
+PciePeReset (
+  UINT32 Segment,
+  BOOLEAN Enable
+  )
+{
+  switch(Segment) {
+    case PCIE_SEGMENT_PCIE20L1:
+      GpioPinWrite (1, GPIO_PIN_PA7, !Enable);
+      break;
+    case PCIE_SEGMENT_PCIE20L2:
+      GpioPinWrite (3, GPIO_PIN_PD1, !Enable);
+      break;
+    default:
+      break;
+  }
+}
+
+VOID
+EFIAPI
+PlatformEarlyInit (
+  VOID
+  )
+{
+  // Configure various things specific to this platform
+}

--- a/edk2-rockchip/Platform/FriendlyElec/NanoPi-R6C/Library/RockchipPlatformLib/RockchipPlatformLib.inf
+++ b/edk2-rockchip/Platform/FriendlyElec/NanoPi-R6C/Library/RockchipPlatformLib/RockchipPlatformLib.inf
@@ -1,0 +1,41 @@
+#
+#  Copyright (c) 2021, Rockchip Limited. All rights reserved.
+#
+#  SPDX-License-Identifier: BSD-2-Clause-Patent
+#
+
+[Defines]
+  INF_VERSION                    = 0x00010019
+  BASE_NAME                      = RockchipPlatformLib
+  FILE_GUID                      = 5178fa86-2fec-11ec-95b4-f42a7dcb925d
+  MODULE_TYPE                    = BASE
+  VERSION_STRING                 = 1.0
+  LIBRARY_CLASS                  = RockchipPlatformLib
+  RKPLATLIB_COMMON_DIR           = Silicon/Rockchip/RK3588/Library/RockchipPlatformLibCommon
+
+[Packages]
+  EmbeddedPkg/EmbeddedPkg.dec
+  MdePkg/MdePkg.dec
+  MdeModulePkg/MdeModulePkg.dec
+  Platform/Rockchip/RK3588/RK3588.dec
+  Silicon/Rockchip/RK3588/RK3588.dec
+  Silicon/Rockchip/RockchipPkg.dec
+
+[LibraryClasses]
+  ArmLib
+  HobLib
+  IoLib
+  MemoryAllocationLib
+  SerialPortLib
+  CruLib
+  GpioLib
+
+[Sources.common]
+  RockchipPlatformLib.c
+  $(RKPLATLIB_COMMON_DIR)/RK3588CruLib.c
+
+[Sources.AARCH64]
+
+[Pcd]
+  gRockchipTokenSpaceGuid.PcdI2cBusCount
+

--- a/edk2-rockchip/Platform/FriendlyElec/NanoPi-R6C/NanoPi-R6C.Modules.fdf.inc
+++ b/edk2-rockchip/Platform/FriendlyElec/NanoPi-R6C/NanoPi-R6C.Modules.fdf.inc
@@ -1,0 +1,14 @@
+## @file
+#
+#  Copyright (c) 2023, Mario Bălănică <mariobalanica02@gmail.com>
+#  Copyright (c) 2023, Sergey Tyuryukanov <s199p.wa1k9r@gmail.com>
+#
+#  SPDX-License-Identifier: BSD-2-Clause-Patent
+#
+##
+
+  # ACPI Support
+  INF RuleOverride = ACPITABLE $(PLATFORM_DIRECTORY)/AcpiTables/AcpiTables.inf
+
+  # Splash screen logo
+  INF $(VENDOR_DIRECTORY)/Drivers/LogoDxe/LogoDxe.inf

--- a/edk2-rockchip/Platform/FriendlyElec/NanoPi-R6C/NanoPi-R6C.dsc
+++ b/edk2-rockchip/Platform/FriendlyElec/NanoPi-R6C/NanoPi-R6C.dsc
@@ -1,0 +1,86 @@
+## @file
+#
+#  Copyright (c) 2014-2018, Linaro Limited. All rights reserved.
+#  Copyright (c) 2023, Molly Sophia <mollysophia379@gmail.com>
+#  Copyright (c) 2023, Mario Bălănică <mariobalanica02@gmail.com>
+#  Copyright (c) 2023, Sergey Tyuryukanov <s199p.wa1k9r@gmail.com>
+#
+#  SPDX-License-Identifier: BSD-2-Clause-Patent
+#
+##
+
+################################################################################
+#
+# Defines Section - statements that will be processed to create a Makefile.
+#
+################################################################################
+[Defines]
+  PLATFORM_NAME                  = NanoPi-R6C
+  PLATFORM_VENDOR                = FriendlyElec
+  PLATFORM_GUID                  = e5022309-24e1-46e0-9d40-dcbc7293e609
+  PLATFORM_VERSION               = 0.2
+  DSC_SPECIFICATION              = 0x00010019
+  OUTPUT_DIRECTORY               = Build/$(PLATFORM_NAME)
+  VENDOR_DIRECTORY               = Platform/$(PLATFORM_VENDOR)
+  PLATFORM_DIRECTORY             = $(VENDOR_DIRECTORY)/$(PLATFORM_NAME)
+  SUPPORTED_ARCHITECTURES        = AARCH64
+  BUILD_TARGETS                  = DEBUG|RELEASE
+  SKUID_IDENTIFIER               = DEFAULT
+  FLASH_DEFINITION               = Silicon/Rockchip/RK3588/RK3588.fdf
+  RK_PLATFORM_FVMAIN_MODULES     = $(PLATFORM_DIRECTORY)/$(PLATFORM_NAME).Modules.fdf.inc
+
+  #
+  # RK3588S-based platform
+  #
+!include Silicon/Rockchip/RK3588/RK3588SPlatform.dsc.inc
+
+################################################################################
+#
+# Library Class section - list of all Library Classes needed by this Platform.
+#
+################################################################################
+
+[LibraryClasses.common]
+  RockchipPlatformLib|$(PLATFORM_DIRECTORY)/Library/RockchipPlatformLib/RockchipPlatformLib.inf
+
+################################################################################
+#
+# Pcd Section - list of all EDK II PCD Entries defined by this Platform.
+#
+################################################################################
+
+[PcdsFixedAtBuild.common]
+  # SMBIOS platform config
+  gRockchipTokenSpaceGuid.PcdPlatformName|"NanoPi R6C"
+  gRockchipTokenSpaceGuid.PcdPlatformVendorName|"FriendlyElec"
+  gRockchipTokenSpaceGuid.PcdFamilyName|"NanoPi"
+  gRockchipTokenSpaceGuid.PcdProductUrl|"https://wiki.friendlyelec.com/wiki/index.php/NanoPi_R6"
+
+  #
+  # CPU Performance default values
+  #
+  gRK3588TokenSpaceGuid.PcdCPULClusterClockPresetDefault|$(CPU_PERF_CLUSTER_CLOCK_PRESET_BOOTDEFAULT)
+  gRK3588TokenSpaceGuid.PcdCPUB01ClusterClockPresetDefault|$(CPU_PERF_CLUSTER_CLOCK_PRESET_BOOTDEFAULT)
+  gRK3588TokenSpaceGuid.PcdCPUB23ClusterClockPresetDefault|$(CPU_PERF_CLUSTER_CLOCK_PRESET_BOOTDEFAULT)
+
+  #
+  # PCIe/SATA/USB Combo PIPE PHY support flags and default values
+  #
+  gRK3588TokenSpaceGuid.PcdComboPhy0Switchable|FALSE
+  gRK3588TokenSpaceGuid.PcdComboPhy2Switchable|FALSE
+  gRK3588TokenSpaceGuid.PcdComboPhy0ModeDefault|$(COMBO_PHY_MODE_PCIE)
+  gRK3588TokenSpaceGuid.PcdComboPhy2ModeDefault|$(COMBO_PHY_MODE_PCIE)
+
+
+################################################################################
+#
+# Components Section - list of all EDK II Modules needed by this Platform.
+#
+################################################################################
+[Components.common]
+  # ACPI Support
+  $(PLATFORM_DIRECTORY)/AcpiTables/AcpiTables.inf
+
+  # Splash screen logo
+  $(VENDOR_DIRECTORY)/Drivers/LogoDxe/LogoDxe.inf
+


### PR DESCRIPTION
Very similar to the NanoPi-R6S, but instead of the RTL8125BG, there is an M.2 NVME SSD on the PCie2 bus.
Has Ethernet 1Gbps gmac.

https://wiki.friendlyelec.com/wiki/index.php/NanoPi_R6C
