### PR TITLE
add usb hub reset gpio for h88k

### DIFF
--- a/edk2-rockchip/Platform/Hinlink/H88K/Library/RockchipPlatformLib/RockchipPlatformLib.c
+++ b/edk2-rockchip/Platform/Hinlink/H88K/Library/RockchipPlatformLib/RockchipPlatformLib.c
@@ -12,6 +12,7 @@
 #include <Library/RK806.h>
 #include <Library/Rk3588Pcie.h>
 #include <Soc.h>
+#include <Library/TimerLib.h>
 
 static struct regulator_init_data rk806_init_data[] = {
   /* Master PMIC */
@@ -201,6 +202,11 @@ UsbPortPowerEnable (
   /* Set GPIO4 PB0 (USB_HOST_PWREN) output high to power USB ports */
   GpioPinSetDirection (4, GPIO_PIN_PB0, GPIO_PIN_OUTPUT);
   GpioPinWrite (4, GPIO_PIN_PB0, TRUE);
+  /* Set GPIO4 PB0 (USB_HUB_PWREN) output high to power USB ports */
+  GpioPinSetDirection (4, GPIO_PIN_PA6, GPIO_PIN_OUTPUT);
+  GpioPinWrite (4, GPIO_PIN_PA6, FALSE);
+  MicroSecondDelay (100);
+  GpioPinWrite (4, GPIO_PIN_PA6, TRUE);
 }
 
 VOID

--- a/edk2-rockchip/Platform/Hinlink/H88K/Library/RockchipPlatformLib/RockchipPlatformLib.inf
+++ b/edk2-rockchip/Platform/Hinlink/H88K/Library/RockchipPlatformLib/RockchipPlatformLib.inf
@@ -28,6 +28,7 @@
   SerialPortLib
   CruLib
   GpioLib
+  TimerLib
 
 [Sources.common]
   RockchipPlatformLib.c


### PR DESCRIPTION
H88K has 4 usb 3.0 port controlled by a usb hub, which has a reset gpio. Set it to low and wait for about 100ms then set it to high, we can init the usb ports well.
Before this patch, the usb ports are randomly init.