### PR TITLE
add sdcard image with EFI partition

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -68,12 +68,16 @@ jobs:
       - name: Build platform
         shell: bash
         run: |
-         ./build.sh --device ${{matrix.PLATFORM}} --release ${{matrix.CONFIGURATION}}
+          ./build.sh --device ${{matrix.PLATFORM}} --release ${{matrix.CONFIGURATION}}
           mv RK3588_NOR_FLASH.img ${{matrix.PLATFORM}}_UEFI_${{matrix.CONFIGURATION}}_${{steps.get_version_tag.outputs.version}}.img
+          mv RK3588_SDCARD_EFI.img ${{matrix.PLATFORM}}_SDCARD_EFI_${{matrix.CONFIGURATION}}_${{steps.get_version_tag.outputs.version}}.img
+          xz -T0 ${{matrix.PLATFORM}}_SDCARD_EFI_${{matrix.CONFIGURATION}}_${{steps.get_version_tag.outputs.version}}.img
 
       - name: Upload artifact
         uses: actions/upload-artifact@v3
         with:
           name: ${{matrix.PLATFORM}} UEFI ${{matrix.CONFIGURATION}} image
-          path: ./*.img
+          path: |
+            ./*.img
+            ./*.img.xz
           if-no-files-found: error

--- a/build.sh
+++ b/build.sh
@@ -76,6 +76,14 @@ function _pack(){
 	# FIT Image at 0x100000
 	dd if=${WORKSPACE}/${DEVICE}_EFI.itb of=${WORKSPACE}/RK3588_NOR_FLASH.img bs=1K seek=1024
 	cp ${WORKSPACE}/RK3588_NOR_FLASH.img ${ROOTDIR}/
+
+	echo " => Building SDCard image with a 300MB EFI partition"
+	fallocate -l 331M RK3588_SDCARD_EFI.img
+	parted -s RK3588_SDCARD_EFI.img mklabel gpt
+	parted -s RK3588_SDCARD_EFI.img unit s mkpart loader 64 32767
+	parted -s RK3588_SDCARD_EFI.img unit s mkpart EFI 32768 331MB
+	dd if=${WORKSPACE}/idblock.bin of=RK3588_SDCARD_EFI.img seek=64 conv=notrunc
+	dd if=${WORKSPACE}/${DEVICE}_EFI.itb of=RK3588_SDCARD_EFI.img seek=20480 conv=notrunc
 }
 
 function _build(){
@@ -101,6 +109,7 @@ function _build(){
 
 	# based on the instructions from edk2-platform
 	rm -f "${OUTDIR}/RK35*_NOR_FLASH.img"
+	rm -f "${OUTDIR}/RK35*_SDCARD_EFI.img"
 
 	case "${MODE}" in
 		RELEASE) _MODE=RELEASE;;


### PR DESCRIPTION
We can flash this image to sdcard or emmc so that we can install system on itself later.