### PR TITLE
remove unused second IDBlock in flash

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,7 +146,6 @@ ACPI support is limited, with only boot critical devices being currently exposed
 | ---------- | ---------- | --------------------- | ---------------------- |
 | 0x00000000 | 0x00004400 | GPT Table             | rk3588_spi_nor_gpt.img |
 | 0x00008000 |            | IDBlock               | idblock.bin            |
-| 0x00088000 |            | IDBlock               | idblock.bin            |
 | 0x00100000 | 0x00500000 | BL33_AP_UEFI FV       | ${DEVICE}_EFI.itb      |
 
 ### Memory Map

--- a/build.sh
+++ b/build.sh
@@ -70,9 +70,8 @@ function _pack(){
 
 	# might be GPT table? size:0x4400
 	dd if=${ROOTDIR}/misc/rk3588_spi_nor_gpt.img of=${WORKSPACE}/RK3588_NOR_FLASH.img
-	# idblock at 0x8000 and 0x88000
+	# idblock at 0x8000
 	dd if=${WORKSPACE}/idblock.bin of=${WORKSPACE}/RK3588_NOR_FLASH.img bs=1K seek=32
-	dd if=${WORKSPACE}/idblock.bin of=${WORKSPACE}/RK3588_NOR_FLASH.img bs=1K seek=544
 	# FIT Image at 0x100000
 	dd if=${WORKSPACE}/${DEVICE}_EFI.itb of=${WORKSPACE}/RK3588_NOR_FLASH.img bs=1K seek=1024
 	cp ${WORKSPACE}/RK3588_NOR_FLASH.img ${ROOTDIR}/


### PR DESCRIPTION
Why do we need it since image still works without it.