### PR TITLE
add devicetree name of board in smbios OEM Strings

### DIFF
--- a/edk2-rockchip/Platform/Ameridroid/IndiedroidNova/IndiedroidNova.dsc
+++ b/edk2-rockchip/Platform/Ameridroid/IndiedroidNova/IndiedroidNova.dsc
@@ -59,6 +59,7 @@
   gRockchipTokenSpaceGuid.PcdPlatformVendorName|"ameriDroid"
   gRockchipTokenSpaceGuid.PcdFamilyName|"Indiedroid"
   gRockchipTokenSpaceGuid.PcdProductUrl|"https://indiedroid.us"
+  gRockchipTokenSpaceGuid.PcdDeviceTreeName|"rk3588s-9tripod-linux.dtb"
 
   # I2C
   gRockchipTokenSpaceGuid.PcdI2cSlaveAddresses|{ 0x42, 0x43, 0x51 }

--- a/edk2-rockchip/Platform/Firefly/ROC-RK3588S-PC/ROC-RK3588S-PC.dsc
+++ b/edk2-rockchip/Platform/Firefly/ROC-RK3588S-PC/ROC-RK3588S-PC.dsc
@@ -42,3 +42,4 @@
   gRockchipTokenSpaceGuid.PcdPlatformVendorName|"Firefly"
   gRockchipTokenSpaceGuid.PcdFamilyName|"ROC"
   gRockchipTokenSpaceGuid.PcdProductUrl|"https://en.t-firefly.com/product/industry/rocrk3588spc"
+  gRockchipTokenSpaceGuid.PcdDeviceTreeName|"roc-rk3588s-pc.dtb"

--- a/edk2-rockchip/Platform/FriendlyElec/NanoPC-T6/NanoPC-T6.dsc
+++ b/edk2-rockchip/Platform/FriendlyElec/NanoPC-T6/NanoPC-T6.dsc
@@ -60,6 +60,7 @@
   gRockchipTokenSpaceGuid.PcdPlatformVendorName|"FriendlyElec"
   gRockchipTokenSpaceGuid.PcdFamilyName|"NanoPi 6"
   gRockchipTokenSpaceGuid.PcdProductUrl|"https://wiki.friendlyelec.com/wiki/index.php/NanoPC-T6"
+  gRockchipTokenSpaceGuid.PcdDeviceTreeName|"rk3588-nanopc-t6.dtb"
 
   # I2C
   gRockchipTokenSpaceGuid.PcdI2cSlaveAddresses|{ 0x42, 0x43, 0x51 }

--- a/edk2-rockchip/Platform/FriendlyElec/NanoPi-R6C/NanoPi-R6C.dsc
+++ b/edk2-rockchip/Platform/FriendlyElec/NanoPi-R6C/NanoPi-R6C.dsc
@@ -61,6 +61,7 @@
   gRockchipTokenSpaceGuid.PcdPlatformVendorName|"FriendlyElec"
   gRockchipTokenSpaceGuid.PcdFamilyName|"NanoPi"
   gRockchipTokenSpaceGuid.PcdProductUrl|"https://wiki.friendlyelec.com/wiki/index.php/NanoPi_R6"
+  gRockchipTokenSpaceGuid.PcdDeviceTreeName|"rk3588s-nanopi-r6c.dtb"
 
   # I2C
   gRockchipTokenSpaceGuid.PcdI2cSlaveAddresses|{ 0x42, 0x43, 0x51 }

--- a/edk2-rockchip/Platform/FriendlyElec/NanoPi-R6S/NanoPi-R6S.dsc
+++ b/edk2-rockchip/Platform/FriendlyElec/NanoPi-R6S/NanoPi-R6S.dsc
@@ -60,6 +60,7 @@
   gRockchipTokenSpaceGuid.PcdPlatformVendorName|"FriendlyElec"
   gRockchipTokenSpaceGuid.PcdFamilyName|"NanoPi 6"
   gRockchipTokenSpaceGuid.PcdProductUrl|"https://wiki.friendlyelec.com/wiki/index.php/NanoPi_R6S"
+  gRockchipTokenSpaceGuid.PcdDeviceTreeName|"rk3588s-nanopi-r6s.dtb"
 
   # I2C
   gRockchipTokenSpaceGuid.PcdI2cSlaveAddresses|{ 0x42, 0x43, 0x51 }

--- a/edk2-rockchip/Platform/Hinlink/H88K/H88K.dsc
+++ b/edk2-rockchip/Platform/Hinlink/H88K/H88K.dsc
@@ -60,6 +60,7 @@
   gRockchipTokenSpaceGuid.PcdPlatformVendorName|"Hinlink"
   gRockchipTokenSpaceGuid.PcdFamilyName|"H88K"
   gRockchipTokenSpaceGuid.PcdProductUrl|"http://www.hinlink.com/"
+  gRockchipTokenSpaceGuid.PcdDeviceTreeName|"rk3588-hinlink-h88k.dtb"
 
   # I2C
   gRockchipTokenSpaceGuid.PcdI2cSlaveAddresses|{ 0x42, 0x43, 0x51 }

--- a/edk2-rockchip/Platform/Khadas/Edge2/Edge2.dsc
+++ b/edk2-rockchip/Platform/Khadas/Edge2/Edge2.dsc
@@ -59,6 +59,7 @@
   gRockchipTokenSpaceGuid.PcdPlatformVendorName|"Khadas"
   gRockchipTokenSpaceGuid.PcdFamilyName|"Edge"
   gRockchipTokenSpaceGuid.PcdProductUrl|"https://www.khadas.com/edge2"
+  gRockchipTokenSpaceGuid.PcdDeviceTreeName|"rk3588s-khadas-edge2.dtb"
 
   # I2C
   gRockchipTokenSpaceGuid.PcdI2cSlaveAddresses|{ 0x42, 0x43, 0x51 }

--- a/edk2-rockchip/Platform/Mekotronics/R58-Mini/R58-Mini.dsc
+++ b/edk2-rockchip/Platform/Mekotronics/R58-Mini/R58-Mini.dsc
@@ -63,6 +63,7 @@
   gRockchipTokenSpaceGuid.PcdFamilyName|"R58"
   gRockchipTokenSpaceGuid.PcdProductUrl|"https://www.mekotronics.com/h-pd-76.html"
   gRockchipTokenSpaceGuid.PcdBoardName|"MINI-PC-RK3588-4D32-V1.0"
+  gRockchipTokenSpaceGuid.PcdDeviceTreeName|"rk3588-blueberry-minipc-linux.dtb"
 
   # I2C
   gRockchipTokenSpaceGuid.PcdI2cSlaveAddresses|{ 0x42, 0x43, 0x51 }

--- a/edk2-rockchip/Platform/Mekotronics/R58X/R58X.dsc
+++ b/edk2-rockchip/Platform/Mekotronics/R58X/R58X.dsc
@@ -60,6 +60,7 @@
   gRockchipTokenSpaceGuid.PcdFamilyName|"R58"
   gRockchipTokenSpaceGuid.PcdProductUrl|"https://www.mekotronics.com/h-pd-75.html"
   gRockchipTokenSpaceGuid.PcdBoardName|"EDGE-RK3588-4D32-V1.2"
+  gRockchipTokenSpaceGuid.PcdDeviceTreeName|"rk3588-blueberry-edge-v10-linux.dtb"
 
   # I2C
   gRockchipTokenSpaceGuid.PcdI2cSlaveAddresses|{ 0x42, 0x43, 0x51 }

--- a/edk2-rockchip/Platform/Mixtile/Blade3/Blade3.dsc
+++ b/edk2-rockchip/Platform/Mixtile/Blade3/Blade3.dsc
@@ -53,6 +53,7 @@
   gRockchipTokenSpaceGuid.PcdPlatformVendorName|"Mixtile"
   gRockchipTokenSpaceGuid.PcdFamilyName|"Blade"
   gRockchipTokenSpaceGuid.PcdProductUrl|"https://www.mixtile.com/blade-3/"
+  gRockchipTokenSpaceGuid.PcdDeviceTreeName|"rk3588-blade3-v101-linux.dtb"
 
   # I2C
   gRockchipTokenSpaceGuid.PcdI2cSlaveAddresses|{ 0x42, 0x43 }

--- a/edk2-rockchip/Platform/OrangePi/OrangePi5/OrangePi5.dsc
+++ b/edk2-rockchip/Platform/OrangePi/OrangePi5/OrangePi5.dsc
@@ -60,6 +60,7 @@
   gRockchipTokenSpaceGuid.PcdPlatformVendorName|"Orange Pi"
   gRockchipTokenSpaceGuid.PcdFamilyName|"Orange Pi 5"
   gRockchipTokenSpaceGuid.PcdProductUrl|"http://www.orangepi.org/html/hardWare/computerAndMicrocontrollers/details/Orange-Pi-5.html"
+  gRockchipTokenSpaceGuid.PcdDeviceTreeName|"rk3588s-orangepi-5.dtb"
 
   # I2C
   gRockchipTokenSpaceGuid.PcdI2cSlaveAddresses|{ 0x42, 0x43, 0x51 }

--- a/edk2-rockchip/Platform/OrangePi/OrangePi5Plus/OrangePi5Plus.dsc
+++ b/edk2-rockchip/Platform/OrangePi/OrangePi5Plus/OrangePi5Plus.dsc
@@ -59,6 +59,7 @@
   gRockchipTokenSpaceGuid.PcdPlatformVendorName|"Orange Pi"
   gRockchipTokenSpaceGuid.PcdFamilyName|"Orange Pi 5"
   gRockchipTokenSpaceGuid.PcdProductUrl|"http://www.orangepi.org/html/hardWare/computerAndMicrocontrollers/details/Orange-Pi-5-plus.html"
+  gRockchipTokenSpaceGuid.PcdDeviceTreeName|"rk3588-orangepi-5-plus.dtb"
 
   # I2C
   gRockchipTokenSpaceGuid.PcdI2cSlaveAddresses|{ 0x42, 0x43, 0x51 }

--- a/edk2-rockchip/Platform/Radxa/ROCK5A/ROCK5A.dsc
+++ b/edk2-rockchip/Platform/Radxa/ROCK5A/ROCK5A.dsc
@@ -54,6 +54,7 @@
   gRockchipTokenSpaceGuid.PcdPlatformVendorName|"Radxa"
   gRockchipTokenSpaceGuid.PcdFamilyName|"ROCK 5"
   gRockchipTokenSpaceGuid.PcdProductUrl|"https://wiki.radxa.com/Rock5/hardware/5a"
+  gRockchipTokenSpaceGuid.PcdDeviceTreeName|"rk3588s-rock-5a.dtb"
 
   # I2C
   gRockchipTokenSpaceGuid.PcdI2cSlaveAddresses|{ 0x42, 0x43 }

--- a/edk2-rockchip/Platform/Radxa/ROCK5B/ROCK5B.dsc
+++ b/edk2-rockchip/Platform/Radxa/ROCK5B/ROCK5B.dsc
@@ -60,6 +60,7 @@
   gRockchipTokenSpaceGuid.PcdPlatformVendorName|"Radxa"
   gRockchipTokenSpaceGuid.PcdFamilyName|"ROCK 5"
   gRockchipTokenSpaceGuid.PcdProductUrl|"https://wiki.radxa.com/Rock5/hardware/5b"
+  gRockchipTokenSpaceGuid.PcdDeviceTreeName|"rk3588-rock-5b.dtb"
 
   # I2C
   gRockchipTokenSpaceGuid.PcdI2cSlaveAddresses|{ 0x42, 0x43, 0x51 }

--- a/edk2-rockchip/Platform/StationPC/StationM3/StationM3.dsc
+++ b/edk2-rockchip/Platform/StationPC/StationM3/StationM3.dsc
@@ -42,6 +42,7 @@
   gRockchipTokenSpaceGuid.PcdPlatformVendorName|"Station PC"
   gRockchipTokenSpaceGuid.PcdFamilyName|"Station M"
   gRockchipTokenSpaceGuid.PcdProductUrl|"https://www.stationpc.com/product/stationm3"
+  gRockchipTokenSpaceGuid.PcdDeviceTreeName|"roc-rk3588s-pc.dtb"
 
   #
   # CPU Performance default values

--- a/edk2-rockchip/Silicon/Rockchip/Drivers/PlatformSmbiosDxe/PlatformSmbiosDxe.c
+++ b/edk2-rockchip/Silicon/Rockchip/Drivers/PlatformSmbiosDxe/PlatformSmbiosDxe.c
@@ -504,13 +504,15 @@ CHAR8 *mSysSlotInfoType9Strings[] = {
 ************************************************************************/
 
 CHAR8 mOemInfoProductUrl[128];
+CHAR8 mOemInfoDeviceTreeName[128];
 
 SMBIOS_TABLE_TYPE11 mOemStringsType11 = {
   { EFI_SMBIOS_TYPE_OEM_STRINGS, sizeof (SMBIOS_TABLE_TYPE11), 0 },
-  1 // StringCount
+  2 // StringCount
 };
 CHAR8 *mOemStringsType11Strings[] = {
   mOemInfoProductUrl,
+  mOemInfoDeviceTreeName,
   NULL
 };
 
@@ -1047,6 +1049,7 @@ OemStringsUpdateSmbiosType11 (
   )
 {
   AsciiStrCpyS (mOemInfoProductUrl, sizeof (mOemInfoProductUrl), (CHAR8 *) PcdGetPtr(PcdProductUrl));
+  AsciiStrCpyS (mOemInfoDeviceTreeName, sizeof (mOemInfoDeviceTreeName), (CHAR8 *) PcdGetPtr(PcdDeviceTreeName));
 
   LogSmbiosData ((EFI_SMBIOS_TABLE_HEADER*)&mOemStringsType11, mOemStringsType11Strings, NULL);
 }

--- a/edk2-rockchip/Silicon/Rockchip/Drivers/PlatformSmbiosDxe/PlatformSmbiosDxe.inf
+++ b/edk2-rockchip/Silicon/Rockchip/Drivers/PlatformSmbiosDxe/PlatformSmbiosDxe.inf
@@ -66,6 +66,7 @@
   gRockchipTokenSpaceGuid.PcdBoardName
   gRockchipTokenSpaceGuid.PcdBoardVendorName
   gRockchipTokenSpaceGuid.PcdProductUrl
+  gRockchipTokenSpaceGuid.PcdDeviceTreeName
   gRockchipTokenSpaceGuid.PcdFamilyName
   gRockchipTokenSpaceGuid.PcdMemoryVendorName
   gEfiMdeModulePkgTokenSpaceGuid.PcdFirmwareVendor

--- a/edk2-rockchip/Silicon/Rockchip/RockchipPkg.dec
+++ b/edk2-rockchip/Silicon/Rockchip/RockchipPkg.dec
@@ -41,6 +41,7 @@
   gRockchipTokenSpaceGuid.PcdProductUrl|"Unknown"|VOID*|0x00000006
   gRockchipTokenSpaceGuid.PcdMemoryVendorName|"Unknown"|VOID*|0x00000007
   gRockchipTokenSpaceGuid.PcdFamilyName|"Unknown"|VOID*|0x00000008
+  gRockchipTokenSpaceGuid.PcdDeviceTreeName|"Unknown"|VOID*|0x00000009
 
   gRockchipTokenSpaceGuid.PcdI2cSlaveAddresses|{ 0x0 }|VOID*|0x02000001
   gRockchipTokenSpaceGuid.PcdI2cSlaveBuses|{ 0x0 }|VOID*|0x02000002


### PR DESCRIPTION
We can read the devicetree name in grub from smbios directly  with command like `smbios -t 11 -s 4 --set=devicetree_name`, and load the correct dtb file.