### PR TITLE
ComboPhy.c - fix COMBO_PHY_MODE_SATA typo

### DIFF
--- a/edk2-rockchip/Silicon/Rockchip/RK3588/Drivers/RK3588Dxe/ComboPhy.c
+++ b/edk2-rockchip/Silicon/Rockchip/RK3588/Drivers/RK3588Dxe/ComboPhy.c
@@ -87,7 +87,7 @@ InitComPhyConfig (
       MmioWrite32 (PhpBaseAddr + 0x0, 0xFFFF0129);
       MmioWrite32 (PhpBaseAddr + 0x4, 0xFFFF4000);
       MmioWrite32 (PhpBaseAddr + 0x8, 0xFFFF80c1);
-      MmioWrite32 (PhpBaseAddr + 0xc, 0xFFFF0407);
+      MmioWrite32 (PhpBaseAddr + 0xc, 0xFFFF4007);
 
       /* Should we tune the rest of the parameters too? */
 


### PR DESCRIPTION
Not sure that it matters, but there is an apparent typo in the value given to PIPE_PHY_GRF_PIPE_CON3 for COMBO_PHY_MODE_SATA. The '4' is probably off by one digit.

Reset value is 0x0002.

Existing SATA-mode value is 0x0407 (pipe_sel=PCIe):

- `0` = qsgm=0, pipe_sel=**00 (PCIe)**, reserved=0.
- `4` = clkreq=0, rxelecidle=**1**, clk_ref_src=00.
- `0` = reserved=0000.
- `7` = txpattern_sata=0, txmargin=1, txdeemph=1, txswing=1.

Likely intended value is 0x4007 (pipe_sel=SATA):

- `4` = qsgm=0, pipe_sel=**10 (SATA)**, reserved=0.
- `0` = clkreq=0, rxelecidle=**0**, clk_ref_src=00.
- `0` = reserved=0000.
- `7` = txpattern_sata=0, txmargin=1, txdeemph=1, txswing=1.