### PR TITLE
Rk3588Mem.c - inconsistent Base System RAM length

### DIFF
--- a/edk2-rockchip/Silicon/Rockchip/RK3588/Library/PlatformLib/Rk3588Mem.c
+++ b/edk2-rockchip/Silicon/Rockchip/RK3588/Library/PlatformLib/Rk3588Mem.c
@@ -81,7 +81,7 @@ ArmPlatformGetVirtualMemoryMap (
   // Base System RAM
   VirtualMemoryTable[Index].PhysicalBase    = mSystemMemoryBase;
   VirtualMemoryTable[Index].VirtualBase     = VirtualMemoryTable[Index].PhysicalBase;
-  VirtualMemoryTable[Index].Length          = MIN (mSystemMemorySize, 0xF0000000UL);
+  VirtualMemoryTable[Index].Length          = MIN (mSystemMemorySize, 0xF0000000UL - mSystemMemoryBase);
   VirtualMemoryTable[Index].Attributes      = ARM_MEMORY_REGION_ATTRIBUTE_WRITE_BACK;
   VirtualMemoryInfo[Index].Type             = RK3588_MEM_BASIC_REGION;
   VirtualMemoryInfo[Index++].Name           = L"System RAM";


### PR DESCRIPTION
The Base System RAM  section nominally starts at `mSystemMemoryBase` but computes its length as if it starts at `0`. This happens to be fine since `mSystemMemoryBase` actually is `0`, so this doesn't cause any real problems, but it seems inconsistent to use a symbol in one place and an implicitly-hard-coded `0` elsewhere.

Fix is to use subtract the value of `mSystemMemoryBase` from the length. Since `mSystemMemoryBase` is `0`, this is a no-op, but it makes the table use consistent logic, and might avoid a future issue if this code is ever copy-pasted somewhere that base is not 0.