### PR TITLE
Silicon/RK3588: Adjust I2C for Windows driver, add DMA, and enable in boards

### DIFF
--- a/edk2-rockchip/Platform/Ameridroid/IndiedroidNova/AcpiTables/Dsdt.asl
+++ b/edk2-rockchip/Platform/Ameridroid/IndiedroidNova/AcpiTables/Dsdt.asl
@@ -21,9 +21,10 @@ DefinitionBlock ("Dsdt.aml", "DSDT", 2, "RKCP  ", "RK3588  ", 2)
 
     include ("Emmc.asl")
     include ("Sdhc.asl")
+    include ("Dma.asl")
     // include ("Gmac.asl")
     include ("Gpio.asl")
-    // include ("I2c.asl")
+    include ("I2c.asl")
     include ("Uart.asl")
     // include ("Spi.asl")
 

--- a/edk2-rockchip/Platform/Firefly/ROC-RK3588S-PC/AcpiTables/Dsdt.asl
+++ b/edk2-rockchip/Platform/Firefly/ROC-RK3588S-PC/AcpiTables/Dsdt.asl
@@ -21,9 +21,10 @@ DefinitionBlock ("Dsdt.aml", "DSDT", 2, "RKCP  ", "RK3588  ", 2)
 
     include ("Emmc.asl")
     include ("Sdhc.asl")
+    include ("Dma.asl")
     include ("Gmac1.asl")
     include ("Gpio.asl")
-    // include ("I2c.asl")
+    include ("I2c.asl")
     include ("Uart.asl")
     // include ("Spi.asl")
 

--- a/edk2-rockchip/Platform/FriendlyElec/NanoPC-T6/AcpiTables/Dsdt.asl
+++ b/edk2-rockchip/Platform/FriendlyElec/NanoPC-T6/AcpiTables/Dsdt.asl
@@ -21,9 +21,10 @@ DefinitionBlock ("Dsdt.aml", "DSDT", 2, "RKCP  ", "RK3588  ", 2)
 
     include ("Emmc.asl")
     include ("Sdhc.asl")
+    include ("Dma.asl")
     // include ("Gmac.asl")
     include ("Gpio.asl")
-    // include ("I2c.asl")
+    include ("I2c.asl")
     include ("Uart.asl")
     // include ("Spi.asl")
 

--- a/edk2-rockchip/Platform/FriendlyElec/NanoPi-R6C/AcpiTables/Dsdt.asl
+++ b/edk2-rockchip/Platform/FriendlyElec/NanoPi-R6C/AcpiTables/Dsdt.asl
@@ -21,9 +21,10 @@ DefinitionBlock ("Dsdt.aml", "DSDT", 2, "RKCP  ", "RK3588S", 2)
 
     include ("Emmc.asl")
     include ("Sdhc.asl")
+    include ("Dma.asl")
     include ("Gmac1.asl")
     include ("Gpio.asl")
-    //include ("I2c.asl")
+    include ("I2c.asl")
     include ("Uart.asl")
     //include ("Spi.asl")
 

--- a/edk2-rockchip/Platform/FriendlyElec/NanoPi-R6S/AcpiTables/Dsdt.asl
+++ b/edk2-rockchip/Platform/FriendlyElec/NanoPi-R6S/AcpiTables/Dsdt.asl
@@ -21,9 +21,10 @@ DefinitionBlock ("Dsdt.aml", "DSDT", 2, "RKCP  ", "RK3588  ", 2)
 
     include ("Emmc.asl")
     include ("Sdhc.asl")
+    include ("Dma.asl")
     include ("Gmac1.asl")
     include ("Gpio.asl")
-    // include ("I2c.asl")
+    include ("I2c.asl")
     include ("Uart.asl")
     // include ("Spi.asl")
 

--- a/edk2-rockchip/Platform/Hinlink/H88K/AcpiTables/Dsdt.asl
+++ b/edk2-rockchip/Platform/Hinlink/H88K/AcpiTables/Dsdt.asl
@@ -21,9 +21,10 @@ DefinitionBlock ("Dsdt.aml", "DSDT", 2, "RKCP  ", "RK3588  ", 2)
 
     include ("Emmc.asl")
     include ("Sdhc.asl")
+    include ("Dma.asl")
     include ("Gmac0.asl")
     include ("Gpio.asl")
-    // include ("I2c.asl")
+    include ("I2c.asl")
     include ("Uart.asl")
     // include ("Spi.asl")
 

--- a/edk2-rockchip/Platform/Khadas/Edge2/AcpiTables/Dsdt.asl
+++ b/edk2-rockchip/Platform/Khadas/Edge2/AcpiTables/Dsdt.asl
@@ -21,9 +21,10 @@ DefinitionBlock ("Dsdt.aml", "DSDT", 2, "RKCP  ", "RK3588  ", 2)
 
     include ("Emmc.asl")
     include ("Sdhc.asl")
+    include ("Dma.asl")
     // include ("Gmac.asl")
     include ("Gpio.asl")
-    // include ("I2c.asl")
+    include ("I2c.asl")
     include ("Uart.asl")
     // include ("Spi.asl")
 

--- a/edk2-rockchip/Platform/Mekotronics/R58-Mini/AcpiTables/Dsdt.asl
+++ b/edk2-rockchip/Platform/Mekotronics/R58-Mini/AcpiTables/Dsdt.asl
@@ -21,9 +21,10 @@ DefinitionBlock ("Dsdt.aml", "DSDT", 2, "RKCP  ", "RK3588  ", 2)
 
     include ("Emmc.asl")
     include ("Sdhc.asl")
+    include ("Dma.asl")
     include ("Gmac0.asl")
     include ("Gpio.asl")
-    // include ("I2c.asl")
+    include ("I2c.asl")
     include ("Uart.asl")
     // include ("Spi.asl")
 

--- a/edk2-rockchip/Platform/Mekotronics/R58X/AcpiTables/Dsdt.asl
+++ b/edk2-rockchip/Platform/Mekotronics/R58X/AcpiTables/Dsdt.asl
@@ -21,10 +21,11 @@ DefinitionBlock ("Dsdt.aml", "DSDT", 2, "RKCP  ", "RK3588  ", 2)
 
     include ("Emmc.asl")
     include ("Sdhc.asl")
+    include ("Dma.asl")
     include ("Gmac0.asl")
     include ("Gmac1.asl")
     // include ("Gpio.asl")
-    // include ("I2c.asl")
+    include ("I2c.asl")
     include ("Uart.asl")
     // include ("Spi.asl")
 

--- a/edk2-rockchip/Platform/Mixtile/Blade3/AcpiTables/Dsdt.asl
+++ b/edk2-rockchip/Platform/Mixtile/Blade3/AcpiTables/Dsdt.asl
@@ -21,9 +21,10 @@ DefinitionBlock ("Dsdt.aml", "DSDT", 2, "RKCP  ", "RK3588  ", 2)
 
     include ("Emmc.asl")
     include ("Sdhc.asl")
+    include ("Dma.asl")
     // include ("Gmac.asl")
     include ("Gpio.asl")
-    // include ("I2c.asl")
+    include ("I2c.asl")
     include ("Uart.asl")
     // include ("Spi.asl")
 

--- a/edk2-rockchip/Platform/OrangePi/OrangePi5/AcpiTables/Dsdt.asl
+++ b/edk2-rockchip/Platform/OrangePi/OrangePi5/AcpiTables/Dsdt.asl
@@ -21,9 +21,10 @@ DefinitionBlock ("Dsdt.aml", "DSDT", 2, "RKCP  ", "RK3588  ", 2)
 
     // include ("Emmc.asl")
     include ("Sdhc.asl")
+    include ("Dma.asl")
     include ("Gmac1.asl")
     include ("Gpio.asl")
-    // include ("I2c.asl")
+    include ("I2c.asl")
     include ("Uart.asl")
     // include ("Spi.asl")
 

--- a/edk2-rockchip/Platform/OrangePi/OrangePi5Plus/AcpiTables/Dsdt.asl
+++ b/edk2-rockchip/Platform/OrangePi/OrangePi5Plus/AcpiTables/Dsdt.asl
@@ -21,9 +21,10 @@ DefinitionBlock ("Dsdt.aml", "DSDT", 2, "RKCP  ", "RK3588  ", 2)
 
     include ("Emmc.asl")
     include ("Sdhc.asl")
+    include ("Dma.asl")
     // include ("Gmac.asl")
     include ("Gpio.asl")
-    // include ("I2c.asl")
+    include ("I2c.asl")
     include ("Uart.asl")
     // include ("Spi.asl")
 

--- a/edk2-rockchip/Platform/Radxa/ROCK5A/AcpiTables/Dsdt.asl
+++ b/edk2-rockchip/Platform/Radxa/ROCK5A/AcpiTables/Dsdt.asl
@@ -21,9 +21,10 @@ DefinitionBlock ("Dsdt.aml", "DSDT", 2, "RKCP  ", "RK3588  ", 2)
 
     include ("Emmc.asl")
     include ("Sdhc.asl")
+    include ("Dma.asl")
     include ("Gmac1.asl")
     include ("Gpio.asl")
-    // include ("I2c.asl")
+    include ("I2c.asl")
     include ("Uart.asl")
     // include ("Spi.asl")
 

--- a/edk2-rockchip/Platform/Radxa/ROCK5B/AcpiTables/Dsdt.asl
+++ b/edk2-rockchip/Platform/Radxa/ROCK5B/AcpiTables/Dsdt.asl
@@ -21,9 +21,10 @@ DefinitionBlock ("Dsdt.aml", "DSDT", 2, "RKCP  ", "RK3588  ", 2)
 
     include ("Emmc.asl")
     include ("Sdhc.asl")
+    include ("Dma.asl")
     // include ("Gmac.asl")
     include ("Gpio.asl")
-    // include ("I2c.asl")
+    include ("I2c.asl")
     include ("Uart.asl")
     // include ("Spi.asl")
 

--- a/edk2-rockchip/Silicon/Rockchip/RK3588/AcpiTables/Dma.asl
+++ b/edk2-rockchip/Silicon/Rockchip/RK3588/AcpiTables/Dma.asl
@@ -1,0 +1,104 @@
+/** @file
+ *
+ *  Copyright (c) 2022, Rockchip Electronics Co. Ltd.
+ *
+ *  SPDX-License-Identifier: BSD-2-Clause-Patent
+ *
+ **/
+#include "AcpiTables.h"
+
+//
+// Description: DMA
+//
+  Device (DMA0)
+  {
+    Name (_HID, "ARMH0330")
+    Name (_UID, 0)
+    Method (_CRS, 0, Serialized)
+    {
+      Name (RBUF, ResourceTemplate ()
+      {
+        Memory32Fixed (ReadWrite,
+          0xFEA10000,         // Address Base
+          0x00004000,         // Address Length
+        )
+        Interrupt (ResourceConsumer, Level, ActiveHigh, Exclusive, ,, )
+        {
+          0x00000076,
+        }
+        Interrupt (ResourceConsumer, Level, ActiveHigh, Exclusive, ,, )
+        {
+          0x00000077,
+        }
+      })
+      Return (RBUF) /* \_SB_.DMA0._CRS.RBUF */
+    }
+    Name (_DSD, Package() {
+      ToUUID("daffd814-6eba-4d8c-8a91-bc9bbf4aa301"),
+      Package () {
+        Package (2) {"ctlrName", "DMA0"}
+      }
+    })
+  }
+
+  Device (DMA1)
+  {
+    Name (_HID, "ARMH0330")
+    Name (_UID, 1)
+    Method (_CRS, 0, Serialized)
+    {
+      Name (RBUF, ResourceTemplate ()
+      {
+        Memory32Fixed (ReadWrite,
+          0xFEA30000,         // Address Base
+          0x00004000,         // Address Length
+        )
+        Interrupt (ResourceConsumer, Level, ActiveHigh, Exclusive, ,, )
+        {
+          0x00000078,
+        }
+        Interrupt (ResourceConsumer, Level, ActiveHigh, Exclusive, ,, )
+        {
+          0x00000079,
+        }
+      })
+      Return (RBUF) /* \_SB_.DMA0._CRS.RBUF */
+    }
+    Name (_DSD, Package() {
+      ToUUID("daffd814-6eba-4d8c-8a91-bc9bbf4aa301"),
+      Package () {
+        Package (2) {"ctlrName", "DMA1"}
+      }
+    })
+  }
+
+  Device (DMA2)
+  {
+    Name (_HID, "ARMH0330")
+    Name (_UID, 2)
+    Method (_CRS, 0, Serialized)
+    {
+      Name (RBUF, ResourceTemplate ()
+      {
+        Memory32Fixed (ReadWrite,
+          0xFED10000,         // Address Base
+          0x00004000,         // Address Length
+        )
+        Interrupt (ResourceConsumer, Level, ActiveHigh, Exclusive, ,, )
+        {
+          0x0000007A,
+        }
+        Interrupt (ResourceConsumer, Level, ActiveHigh, Exclusive, ,, )
+        {
+          0x0000007B,
+        }
+      })
+      Return (RBUF) /* \_SB_.DMA0._CRS.RBUF */
+    }
+    Name (_DSD, Package() {
+      ToUUID("daffd814-6eba-4d8c-8a91-bc9bbf4aa301"),
+      Package () {
+        Package (2) {"ctlrName", "DMA2"}
+      }
+    })
+  }

--- a/edk2-rockchip/Silicon/Rockchip/RK3588/AcpiTables/I2c.asl
+++ b/edk2-rockchip/Silicon/Rockchip/RK3588/AcpiTables/I2c.asl
@@ -7,8 +7,34 @@
  **/
 #include "AcpiTables.h"
 
+  Device (I2C1) {
+    Name (_HID, "RKCP3001")
+    Name (_CID, "PRP0001")
+    Name (_UID, 1)
+    Name (_CCA, 0)
+
+    Method (_CRS, 0x0, Serialized) {
+      Name (RBUF, ResourceTemplate() {
+        Memory32Fixed (ReadWrite, 0xfea90000, 0x1000)
+        Interrupt (ResourceConsumer, Level, ActiveHigh, Exclusive) { 350 }
+      })
+      Return (RBUF)
+    }
+    Name (_DSD, Package () {
+      ToUUID("daffd814-6eba-4d8c-8a91-bc9bbf4aa301"),
+      Package () {
+        Package (2) { "i2c,clk-rate", 198000000 },
+        Package (2) { "rockchip,bclk", 198000000 },
+        Package (2) { "compatible", "rockchip,rk3399-i2c" },
+        Package (2) { "#address-cells", 1 },
+        Package (2) { "#size-cells", 0 },
+      }
+    })
+  }
+
   Device (I2C2) {
-    Name (_HID, "PRP0001")
+    Name (_HID, "RKCP3001")
+    Name (_CID, "PRP0001")
     Name (_UID, 2)
     Name (_CCA, 0)
 
@@ -23,33 +49,160 @@
       ToUUID("daffd814-6eba-4d8c-8a91-bc9bbf4aa301"),
       Package () {
         Package (2) { "i2c,clk-rate", 198000000 },
+        Package (2) { "rockchip,bclk", 198000000 },
         Package (2) { "compatible", "rockchip,rk3399-i2c" },
         Package (2) { "#address-cells", 1 },
         Package (2) { "#size-cells", 0 },
       }
     })
+  }
 
-    OperationRegion(I2PC, SystemMemory, 0xFD7C0828, 0x4)
-      Field(I2PC, DWordAcc, Lock, WriteAsZeros) {
-      CG10, 32,
-    }
+  Device (I2C3) {
+    Name (_HID, "RKCP3001")
+    Name (_CID, "PRP0001")
+    Name (_UID, 3)
+    Name (_CCA, 0)
 
-    OperationRegion(I2SC, SystemMemory, 0xFD7C082c, 0x4)
-      Field(I2SC, DWordAcc, Lock, WriteAsZeros) {
-      CG11, 32,
+    Method (_CRS, 0x0, Serialized) {
+      Name (RBUF, ResourceTemplate() {
+        Memory32Fixed (ReadWrite, 0xfeab0000, 0x1000)
+        Interrupt (ResourceConsumer, Level, ActiveHigh, Exclusive) { 352 }
+      })
+      Return (RBUF)
     }
+    Name (_DSD, Package () {
+      ToUUID("daffd814-6eba-4d8c-8a91-bc9bbf4aa301"),
+      Package () {
+        Package (2) { "i2c,clk-rate", 198000000 },
+        Package (2) { "rockchip,bclk", 198000000 },
+        Package (2) { "compatible", "rockchip,rk3399-i2c" },
+        Package (2) { "#address-cells", 1 },
+        Package (2) { "#size-cells", 0 },
+      }
+    })
+  }
 
-    Method(_PS3) {
-      Store (0x02000200, CG10)
-      Store (0x00020002, CG11)
-    }
+  Device (I2C4) {
+    Name (_HID, "RKCP3001")
+    Name (_CID, "PRP0001")
+    Name (_UID, 4)
+    Name (_CCA, 0)
 
-    Method(_PS0) {
-      Store (0x02000000, CG10)
-      Store (0x00020000, CG11)
+    Method (_CRS, 0x0, Serialized) {
+      Name (RBUF, ResourceTemplate() {
+        Memory32Fixed (ReadWrite, 0xfeac0000, 0x1000)
+        Interrupt (ResourceConsumer, Level, ActiveHigh, Exclusive) { 353 }
+      })
+      Return (RBUF)
     }
+    Name (_DSD, Package () {
+      ToUUID("daffd814-6eba-4d8c-8a91-bc9bbf4aa301"),
+      Package () {
+        Package (2) { "i2c,clk-rate", 198000000 },
+        Package (2) { "rockchip,bclk", 198000000 },
+        Package (2) { "compatible", "rockchip,rk3399-i2c" },
+        Package (2) { "#address-cells", 1 },
+        Package (2) { "#size-cells", 0 },
+      }
+    })
+  }
 
-    Method(_PSC) {
-      Return(0x01)
+  Device (I2C5) {
+    Name (_HID, "RKCP3001")
+    Name (_CID, "PRP0001")
+    Name (_UID, 5)
+    Name (_CCA, 0)
+
+    Method (_CRS, 0x0, Serialized) {
+      Name (RBUF, ResourceTemplate() {
+        Memory32Fixed (ReadWrite, 0xfead0000, 0x1000)
+        Interrupt (ResourceConsumer, Level, ActiveHigh, Exclusive) { 354 }
+      })
+      Return (RBUF)
     }
+    Name (_DSD, Package () {
+      ToUUID("daffd814-6eba-4d8c-8a91-bc9bbf4aa301"),
+      Package () {
+        Package (2) { "i2c,clk-rate", 198000000 },
+        Package (2) { "rockchip,bclk", 198000000 },
+        Package (2) { "compatible", "rockchip,rk3399-i2c" },
+        Package (2) { "#address-cells", 1 },
+        Package (2) { "#size-cells", 0 },
+      }
+    })
+  }
+
+  Device (I2C6) {
+    Name (_HID, "RKCP3001")
+    Name (_CID, "PRP0001")
+    Name (_UID, 6)
+    Name (_CCA, 0)
+
+    Method (_CRS, 0x0, Serialized) {
+      Name (RBUF, ResourceTemplate() {
+        Memory32Fixed (ReadWrite, 0xfec80000, 0x1000)
+        Interrupt (ResourceConsumer, Level, ActiveHigh, Exclusive) { 355 }
+      })
+      Return (RBUF)
+    }
+    Name (_DSD, Package () {
+      ToUUID("daffd814-6eba-4d8c-8a91-bc9bbf4aa301"),
+      Package () {
+        Package (2) { "i2c,clk-rate", 198000000 },
+        Package (2) { "rockchip,bclk", 198000000 },
+        Package (2) { "compatible", "rockchip,rk3399-i2c" },
+        Package (2) { "#address-cells", 1 },
+        Package (2) { "#size-cells", 0 },
+      }
+    })
+  }
+
+  Device (I2C7) {
+    Name (_HID, "RKCP3001")
+    Name (_CID, "PRP0001")
+    Name (_UID, 7)
+    Name (_CCA, 0)
+
+    Method (_CRS, 0x0, Serialized) {
+      Name (RBUF, ResourceTemplate() {
+        Memory32Fixed (ReadWrite, 0xfec90000, 0x1000)
+        Interrupt (ResourceConsumer, Level, ActiveHigh, Exclusive) { 356 }
+      })
+      Return (RBUF)
+    }
+    Name (_DSD, Package () {
+      ToUUID("daffd814-6eba-4d8c-8a91-bc9bbf4aa301"),
+      Package () {
+        Package (2) { "i2c,clk-rate", 198000000 },
+        Package (2) { "rockchip,bclk", 198000000 },
+        Package (2) { "compatible", "rockchip,rk3399-i2c" },
+        Package (2) { "#address-cells", 1 },
+        Package (2) { "#size-cells", 0 },
+      }
+    })
+  }
+
+  Device (I2C8) {
+    Name (_HID, "RKCP3001")
+    Name (_CID, "PRP0001")
+    Name (_UID, 8)
+    Name (_CCA, 0)
+
+    Method (_CRS, 0x0, Serialized) {
+      Name (RBUF, ResourceTemplate() {
+        Memory32Fixed (ReadWrite, 0xfeca0000, 0x1000)
+        Interrupt (ResourceConsumer, Level, ActiveHigh, Exclusive) { 357 }
+      })
+      Return (RBUF)
+    }
+    Name (_DSD, Package () {
+      ToUUID("daffd814-6eba-4d8c-8a91-bc9bbf4aa301"),
+      Package () {
+        Package (2) { "i2c,clk-rate", 198000000 },
+        Package (2) { "rockchip,bclk", 198000000 },
+        Package (2) { "compatible", "rockchip,rk3399-i2c" },
+        Package (2) { "#address-cells", 1 },
+        Package (2) { "#size-cells", 0 },
+      }
+    })
   }


### PR DESCRIPTION
Adjust I2C for Windows driver and enable in boards. Add DMA and enable in boards. Verify I2C and DMA controllers show up and are functional in device manager in Win11