### PR TITLE
GMAC - add hardware IDs for use by Windows

### DIFF
--- a/edk2-rockchip/Silicon/Rockchip/RK3588/AcpiTables/Gmac0.asl
+++ b/edk2-rockchip/Silicon/Rockchip/RK3588/AcpiTables/Gmac0.asl
@@ -11,7 +11,10 @@
 
 // Gigabit Media Access Controller (GMAC0)
 Device (MAC0) {
-  Name (_HID, "PRP0001")
+  Name (_HID, "RKCP6543")
+  Name (_CID, Package() {
+    "PRP0001"
+  })
   Name (_UID, 60)
   Name (_CCA, 0)
   Name (_STA, 0xF)

--- a/edk2-rockchip/Silicon/Rockchip/RK3588/AcpiTables/Gmac1.asl
+++ b/edk2-rockchip/Silicon/Rockchip/RK3588/AcpiTables/Gmac1.asl
@@ -11,7 +11,10 @@
 
 // Gigabit Media Access Controller (GMAC1)
 Device (MAC1) {
-  Name (_HID, "PRP0001")
+  Name (_HID, "RKCP6543")
+  Name (_CID, Package() {
+    "PRP0001"
+  })
   Name (_UID, 61)
   Name (_CCA, 0)
   Name (_STA, 0xF)


### PR DESCRIPTION
Set GMAC HID to RKCP6543 (arbitrarily-chosen, open to alternatives).

Move the PRP0001 id to `_CID`.