### PR TITLE
Fix WiFi on the OrangePi 5 Plus.

### DIFF
--- a/edk2-rockchip/Platform/FriendlyElec/NanoPC-T6/Library/RockchipPlatformLib/RockchipPlatformLib.c
+++ b/edk2-rockchip/Platform/FriendlyElec/NanoPC-T6/Library/RockchipPlatformLib/RockchipPlatformLib.c
@@ -209,6 +209,10 @@ UsbPortPowerEnable (
   GpioPinWrite (4, GPIO_PIN_PB0, TRUE);
   GpioPinSetDirection (4, GPIO_PIN_PB0, GPIO_PIN_OUTPUT);
 
+  /* Set GPIO4 PC6 output high to power the 4G/LTE module */
+  GpioPinWrite (4, GPIO_PIN_PC6, TRUE);
+  GpioPinSetDirection (4, GPIO_PIN_PC6, GPIO_PIN_OUTPUT);
+
   /* Set GPIO1 PD2 (TYPEC5V_PWREN) output high to power the type-c port */
   GpioPinWrite (1, GPIO_PIN_PD2, TRUE);
   GpioPinSetDirection (1, GPIO_PIN_PD2, GPIO_PIN_OUTPUT);

--- a/edk2-rockchip/Platform/FriendlyElec/NanoPC-T6/NanoPC-T6.Modules.fdf.inc
+++ b/edk2-rockchip/Platform/FriendlyElec/NanoPC-T6/NanoPC-T6.Modules.fdf.inc
@@ -15,4 +15,4 @@
   }
 
   # Splash screen logo
-  INF MdeModulePkg/Logo/LogoDxe.inf
+  INF $(VENDOR_DIRECTORY)/Drivers/LogoDxe/LogoDxe.inf

--- a/edk2-rockchip/Platform/FriendlyElec/NanoPC-T6/NanoPC-T6.dsc
+++ b/edk2-rockchip/Platform/FriendlyElec/NanoPC-T6/NanoPC-T6.dsc
@@ -108,4 +108,4 @@
   $(PLATFORM_DIRECTORY)/AcpiTables/AcpiTables.inf
 
   # Splash screen logo
-  MdeModulePkg/Logo/LogoDxe.inf
+  $(VENDOR_DIRECTORY)/Drivers/LogoDxe/LogoDxe.inf

--- a/edk2-rockchip/Platform/OrangePi/OrangePi5Plus/Library/RockchipPlatformLib/RockchipPlatformLib.c
+++ b/edk2-rockchip/Platform/OrangePi/OrangePi5Plus/Library/RockchipPlatformLib/RockchipPlatformLib.c
@@ -367,9 +367,21 @@ PlatformSetStatusLed (
 
 VOID
 EFIAPI
+PlatformWiFiEnable (
+  IN BOOLEAN Enable
+  )
+{
+  // WiFi - enable
+  GpioPinWrite (0, GPIO_PIN_PC4, Enable);
+  GpioPinSetDirection (0, GPIO_PIN_PC4, GPIO_PIN_OUTPUT);
+}
+
+VOID
+EFIAPI
 PlatformEarlyInit (
   VOID
   )
 {
   // Configure various things specific to this platform
+  PlatformWiFiEnable (TRUE);
 }


### PR DESCRIPTION
Unlike Rock 5A/B and NanoPC-T6, the WiFi module did not work on the OrangePi 5 Plus. 
It was detected on the PCIe bus, but did not emit anything.

![photo_2023-10-13_00-46-24](https://github.com/edk2-porting/edk2-rk3588/assets/41041031/1a344b37-16bf-45e1-acae-58e953a3153b)

Tested on FreeBSD 14.0. With this module.


Maybe Windows 11 also has a driver for this.