### PR TITLE
Platform/RK3588: Refactor I2cIoMux to use GpioPinSetFunction and add missing controllers

### DIFF
--- a/edk2-rockchip/Platform/Ameridroid/IndiedroidNova/Library/RockchipPlatformLib/RockchipPlatformLib.c
+++ b/edk2-rockchip/Platform/Ameridroid/IndiedroidNova/Library/RockchipPlatformLib/RockchipPlatformLib.c
@@ -149,16 +149,12 @@ I2cIomux (
     GpioPinSetFunction(0, GPIO_PIN_PD2, 3); //i2c0_sda_m2
     break;
   case 1:
-    GpioPinSetFunction(0, GPIO_PIN_PB5, 9); //i2c1_scl_m0
-    GpioPinSetFunction(0, GPIO_PIN_PB6, 9); //i2c1_sda_m0
     break;
   case 2:
     GpioPinSetFunction(0, GPIO_PIN_PB7, 9); //i2c2_scl_m0
     GpioPinSetFunction(0, GPIO_PIN_PC0, 9); //i2c2_sda_m0
     break;
   case 3:
-    GpioPinSetFunction(1, GPIO_PIN_PC1, 9); //i2c3_scl_m0
-    GpioPinSetFunction(1, GPIO_PIN_PC0, 9); //i2c3_sda_m0
     break;
   case 4:
     GpioPinSetFunction(1, GPIO_PIN_PA3, 9); //i2c4_scl_m3

--- a/edk2-rockchip/Platform/Ameridroid/IndiedroidNova/Library/RockchipPlatformLib/RockchipPlatformLib.c
+++ b/edk2-rockchip/Platform/Ameridroid/IndiedroidNova/Library/RockchipPlatformLib/RockchipPlatformLib.c
@@ -145,8 +145,8 @@ I2cIomux (
 {
   switch (id) {
   case 0:
-    GpioPinSetFunction(0, GPIO_PIN_PB3, 2); //i2c0_scl_m0
-    GpioPinSetFunction(0, GPIO_PIN_PA6, 2); //i2c0_sda_m0
+    GpioPinSetFunction(0, GPIO_PIN_PD1, 3); //i2c0_scl_m2
+    GpioPinSetFunction(0, GPIO_PIN_PD2, 3); //i2c0_sda_m2
     break;
   case 1:
     GpioPinSetFunction(0, GPIO_PIN_PB5, 9); //i2c1_scl_m0
@@ -161,16 +161,16 @@ I2cIomux (
     GpioPinSetFunction(1, GPIO_PIN_PC0, 9); //i2c3_sda_m0
     break;
   case 4:
-    GpioPinSetFunction(3, GPIO_PIN_PA6, 9); //i2c4_scl_m0
-    GpioPinSetFunction(3, GPIO_PIN_PA5, 9); //i2c4_sda_m0
+    GpioPinSetFunction(1, GPIO_PIN_PA3, 9); //i2c4_scl_m3
+    GpioPinSetFunction(1, GPIO_PIN_PA2, 9); //i2c4_sda_m3
     break;
   case 5:
     GpioPinSetFunction(3, GPIO_PIN_PC7, 9); //i2c5_scl_m0
     GpioPinSetFunction(3, GPIO_PIN_PD0, 9); //i2c5_sda_m0
     break;
   case 6:
-    GpioPinSetFunction(0, GPIO_PIN_PD0, 9); //i2c6_scl_m0
-    GpioPinSetFunction(0, GPIO_PIN_PC7, 9); //i2c6_sda_m0
+    GpioPinSetFunction(4, GPIO_PIN_PB1, 9); //i2c6_scl_m3
+    GpioPinSetFunction(4, GPIO_PIN_PB0, 9); //i2c6_sda_m3
     break;
   case 7:
     GpioPinSetFunction(1, GPIO_PIN_PD0, 9); //i2c7_scl_m0

--- a/edk2-rockchip/Platform/Ameridroid/IndiedroidNova/Library/RockchipPlatformLib/RockchipPlatformLib.c
+++ b/edk2-rockchip/Platform/Ameridroid/IndiedroidNova/Library/RockchipPlatformLib/RockchipPlatformLib.c
@@ -145,32 +145,36 @@ I2cIomux (
 {
   switch (id) {
   case 0:
-    /* io mux M2 */
-    PMU2_IOC->GPIO0D_IOMUX_SEL_L = (0x0F00UL << 16) | 0x0300;
-    PMU2_IOC->GPIO0D_IOMUX_SEL_L = (0x00F0UL << 16) | 0x0030;
+    GpioPinSetFunction(0, GPIO_PIN_PB3, 2); //i2c0_scl_m0
+    GpioPinSetFunction(0, GPIO_PIN_PA6, 2); //i2c0_sda_m0
     break;
   case 1:
-    /* io mux */
-    //BUS_IOC->GPIO0B_IOMUX_SEL_H = (0x0FF0UL << 16) | 0x0990;
-    //PMU2_IOC->GPIO0B_IOMUX_SEL_H = (0x0FF0UL << 16) | 0x0880;
+    GpioPinSetFunction(0, GPIO_PIN_PB5, 9); //i2c1_scl_m0
+    GpioPinSetFunction(0, GPIO_PIN_PB6, 9); //i2c1_sda_m0
     break;
   case 2:
-    /* io mux */
-    BUS_IOC->GPIO0B_IOMUX_SEL_H = (0xF000UL << 16) | 0x9000;
-    BUS_IOC->GPIO0C_IOMUX_SEL_L = (0x000FUL << 16) | 0x0009;
-    PMU2_IOC->GPIO0B_IOMUX_SEL_H = (0xF000UL << 16) | 0x8000;
-    PMU2_IOC->GPIO0C_IOMUX_SEL_L = (0x000FUL << 16) | 0x0008;
+    GpioPinSetFunction(0, GPIO_PIN_PB7, 9); //i2c2_scl_m0
+    GpioPinSetFunction(0, GPIO_PIN_PC0, 9); //i2c2_sda_m0
     break;
   case 3:
+    GpioPinSetFunction(1, GPIO_PIN_PC1, 9); //i2c3_scl_m0
+    GpioPinSetFunction(1, GPIO_PIN_PC0, 9); //i2c3_sda_m0
     break;
   case 4:
+    GpioPinSetFunction(3, GPIO_PIN_PA6, 9); //i2c4_scl_m0
+    GpioPinSetFunction(3, GPIO_PIN_PA5, 9); //i2c4_sda_m0
     break;
   case 5:
+    GpioPinSetFunction(3, GPIO_PIN_PC7, 9); //i2c5_scl_m0
+    GpioPinSetFunction(3, GPIO_PIN_PD0, 9); //i2c5_sda_m0
     break;
   case 6:
-    /* io mux M3 */
-    BUS_IOC->GPIO4B_IOMUX_SEL_L = (0x00F0UL << 16) | 0x0090;
-    BUS_IOC->GPIO4B_IOMUX_SEL_L = (0x000FUL << 16) | 0x0009;
+    GpioPinSetFunction(0, GPIO_PIN_PD0, 9); //i2c6_scl_m0
+    GpioPinSetFunction(0, GPIO_PIN_PC7, 9); //i2c6_sda_m0
+    break;
+  case 7:
+    GpioPinSetFunction(1, GPIO_PIN_PD0, 9); //i2c7_scl_m0
+    GpioPinSetFunction(1, GPIO_PIN_PD1, 9); //i2c7_sda_m0
     break;
   default:
     break;

--- a/edk2-rockchip/Platform/Firefly/ROC-RK3588S-PC/Library/RockchipPlatformLib/RockchipPlatformLib.c
+++ b/edk2-rockchip/Platform/Firefly/ROC-RK3588S-PC/Library/RockchipPlatformLib/RockchipPlatformLib.c
@@ -197,27 +197,36 @@ I2cIomux (
 {
   switch (id) {
   case 0:
-    /* io mux M2 */
-    PMU2_IOC->GPIO0D_IOMUX_SEL_L = (0x0F00UL << 16) | 0x0300;
-    PMU2_IOC->GPIO0D_IOMUX_SEL_L = (0x00F0UL << 16) | 0x0030;
+    GpioPinSetFunction(0, GPIO_PIN_PB3, 2); //i2c0_scl_m0
+    GpioPinSetFunction(0, GPIO_PIN_PA6, 2); //i2c0_sda_m0
     break;
   case 1:
-    /* io mux */
-    //BUS_IOC->GPIO0B_IOMUX_SEL_H = (0x0FF0UL << 16) | 0x0990;
-    //PMU2_IOC->GPIO0B_IOMUX_SEL_H = (0x0FF0UL << 16) | 0x0880;
+    GpioPinSetFunction(0, GPIO_PIN_PB5, 9); //i2c1_scl_m0
+    GpioPinSetFunction(0, GPIO_PIN_PB6, 9); //i2c1_sda_m0
     break;
   case 2:
-    /* io mux */
-    BUS_IOC->GPIO0B_IOMUX_SEL_H = (0xF000UL << 16) | 0x9000;
-    BUS_IOC->GPIO0C_IOMUX_SEL_L = (0x000FUL << 16) | 0x0009;
-    PMU2_IOC->GPIO0B_IOMUX_SEL_H = (0xF000UL << 16) | 0x8000;
-    PMU2_IOC->GPIO0C_IOMUX_SEL_L = (0x000FUL << 16) | 0x0008;
+    GpioPinSetFunction(0, GPIO_PIN_PB7, 9); //i2c2_scl_m0
+    GpioPinSetFunction(0, GPIO_PIN_PC0, 9); //i2c2_sda_m0
     break;
   case 3:
+    GpioPinSetFunction(1, GPIO_PIN_PC1, 9); //i2c3_scl_m0
+    GpioPinSetFunction(1, GPIO_PIN_PC0, 9); //i2c3_sda_m0
     break;
   case 4:
+    GpioPinSetFunction(3, GPIO_PIN_PA6, 9); //i2c4_scl_m0
+    GpioPinSetFunction(3, GPIO_PIN_PA5, 9); //i2c4_sda_m0
     break;
   case 5:
+    GpioPinSetFunction(3, GPIO_PIN_PC7, 9); //i2c5_scl_m0
+    GpioPinSetFunction(3, GPIO_PIN_PD0, 9); //i2c5_sda_m0
+    break;
+  case 6:
+    GpioPinSetFunction(0, GPIO_PIN_PD0, 9); //i2c6_scl_m0
+    GpioPinSetFunction(0, GPIO_PIN_PC7, 9); //i2c6_sda_m0
+    break;
+  case 7:
+    GpioPinSetFunction(1, GPIO_PIN_PD0, 9); //i2c7_scl_m0
+    GpioPinSetFunction(1, GPIO_PIN_PD1, 9); //i2c7_sda_m0
     break;
   default:
     break;

--- a/edk2-rockchip/Platform/Firefly/ROC-RK3588S-PC/Library/RockchipPlatformLib/RockchipPlatformLib.c
+++ b/edk2-rockchip/Platform/Firefly/ROC-RK3588S-PC/Library/RockchipPlatformLib/RockchipPlatformLib.c
@@ -201,8 +201,6 @@ I2cIomux (
     GpioPinSetFunction(0, GPIO_PIN_PD2, 3); //i2c0_sda_m2
     break;
   case 1:
-    GpioPinSetFunction(0, GPIO_PIN_PB5, 9); //i2c1_scl_m0
-    GpioPinSetFunction(0, GPIO_PIN_PB6, 9); //i2c1_sda_m0
     break;
   case 2:
     GpioPinSetFunction(0, GPIO_PIN_PB7, 9); //i2c2_scl_m0
@@ -217,8 +215,6 @@ I2cIomux (
     GpioPinSetFunction(1, GPIO_PIN_PA2, 9); //i2c4_sda_m3
     break;
   case 5:
-    GpioPinSetFunction(3, GPIO_PIN_PC7, 9); //i2c5_scl_m0
-    GpioPinSetFunction(3, GPIO_PIN_PD0, 9); //i2c5_sda_m0
     break;
   case 6:
     GpioPinSetFunction(4, GPIO_PIN_PB1, 9); //i2c6_scl_m3

--- a/edk2-rockchip/Platform/Firefly/ROC-RK3588S-PC/Library/RockchipPlatformLib/RockchipPlatformLib.c
+++ b/edk2-rockchip/Platform/Firefly/ROC-RK3588S-PC/Library/RockchipPlatformLib/RockchipPlatformLib.c
@@ -197,8 +197,8 @@ I2cIomux (
 {
   switch (id) {
   case 0:
-    GpioPinSetFunction(0, GPIO_PIN_PB3, 2); //i2c0_scl_m0
-    GpioPinSetFunction(0, GPIO_PIN_PA6, 2); //i2c0_sda_m0
+    GpioPinSetFunction(0, GPIO_PIN_PD1, 3); //i2c0_scl_m2
+    GpioPinSetFunction(0, GPIO_PIN_PD2, 3); //i2c0_sda_m2
     break;
   case 1:
     GpioPinSetFunction(0, GPIO_PIN_PB5, 9); //i2c1_scl_m0
@@ -213,16 +213,16 @@ I2cIomux (
     GpioPinSetFunction(1, GPIO_PIN_PC0, 9); //i2c3_sda_m0
     break;
   case 4:
-    GpioPinSetFunction(3, GPIO_PIN_PA6, 9); //i2c4_scl_m0
-    GpioPinSetFunction(3, GPIO_PIN_PA5, 9); //i2c4_sda_m0
+    GpioPinSetFunction(1, GPIO_PIN_PA3, 9); //i2c4_scl_m3 
+    GpioPinSetFunction(1, GPIO_PIN_PA2, 9); //i2c4_sda_m3
     break;
   case 5:
     GpioPinSetFunction(3, GPIO_PIN_PC7, 9); //i2c5_scl_m0
     GpioPinSetFunction(3, GPIO_PIN_PD0, 9); //i2c5_sda_m0
     break;
   case 6:
-    GpioPinSetFunction(0, GPIO_PIN_PD0, 9); //i2c6_scl_m0
-    GpioPinSetFunction(0, GPIO_PIN_PC7, 9); //i2c6_sda_m0
+    GpioPinSetFunction(4, GPIO_PIN_PB1, 9); //i2c6_scl_m3
+    GpioPinSetFunction(4, GPIO_PIN_PB0, 9); //i2c6_sda_m3
     break;
   case 7:
     GpioPinSetFunction(1, GPIO_PIN_PD0, 9); //i2c7_scl_m0

--- a/edk2-rockchip/Platform/FriendlyElec/NanoPC-T6/Library/RockchipPlatformLib/RockchipPlatformLib.c
+++ b/edk2-rockchip/Platform/FriendlyElec/NanoPC-T6/Library/RockchipPlatformLib/RockchipPlatformLib.c
@@ -168,8 +168,6 @@ I2cIomux (
     GpioPinSetFunction(0, GPIO_PIN_PD2, 3); //i2c0_sda_m2
     break;
   case 1:
-    GpioPinSetFunction(0, GPIO_PIN_PB5, 9); //i2c1_scl_m0
-    GpioPinSetFunction(0, GPIO_PIN_PB6, 9); //i2c1_sda_m0
     break;
   case 2:
     GpioPinSetFunction(0, GPIO_PIN_PB7, 9); //i2c2_scl_m0
@@ -180,20 +178,14 @@ I2cIomux (
     GpioPinSetFunction(1, GPIO_PIN_PC0, 9); //i2c3_sda_m0
     break;
   case 4:
-    GpioPinSetFunction(1, GPIO_PIN_PA3, 9); //i2c4_scl_m3
-    GpioPinSetFunction(1, GPIO_PIN_PA2, 9); //i2c4_sda_m3
     break;
   case 5:
-    GpioPinSetFunction(1, GPIO_PIN_PB6, 9); //i2c5_scl_m3
-    GpioPinSetFunction(1, GPIO_PIN_PB7, 9); //i2c5_sda_m3
     break;
   case 6:
     GpioPinSetFunction(0, GPIO_PIN_PD0, 9); //i2c6_scl_m0
     GpioPinSetFunction(0, GPIO_PIN_PC7, 9); //i2c6_sda_m0
     break;
   case 7:
-    GpioPinSetFunction(1, GPIO_PIN_PD0, 9); //i2c7_scl_m0
-    GpioPinSetFunction(1, GPIO_PIN_PD1, 9); //i2c7_sda_m0
     break;
   default:
     break;

--- a/edk2-rockchip/Platform/FriendlyElec/NanoPC-T6/Library/RockchipPlatformLib/RockchipPlatformLib.c
+++ b/edk2-rockchip/Platform/FriendlyElec/NanoPC-T6/Library/RockchipPlatformLib/RockchipPlatformLib.c
@@ -164,8 +164,8 @@ I2cIomux (
 {
   switch (id) {
   case 0:
-    GpioPinSetFunction(0, GPIO_PIN_PB3, 2); //i2c0_scl_m0
-    GpioPinSetFunction(0, GPIO_PIN_PA6, 2); //i2c0_sda_m0
+    GpioPinSetFunction(0, GPIO_PIN_PD1, 3); //i2c0_scl_m2
+    GpioPinSetFunction(0, GPIO_PIN_PD2, 3); //i2c0_sda_m2
     break;
   case 1:
     GpioPinSetFunction(0, GPIO_PIN_PB5, 9); //i2c1_scl_m0
@@ -180,12 +180,12 @@ I2cIomux (
     GpioPinSetFunction(1, GPIO_PIN_PC0, 9); //i2c3_sda_m0
     break;
   case 4:
-    GpioPinSetFunction(3, GPIO_PIN_PA6, 9); //i2c4_scl_m0
-    GpioPinSetFunction(3, GPIO_PIN_PA5, 9); //i2c4_sda_m0
+    GpioPinSetFunction(1, GPIO_PIN_PA3, 9); //i2c4_scl_m3
+    GpioPinSetFunction(1, GPIO_PIN_PA2, 9); //i2c4_sda_m3
     break;
   case 5:
-    GpioPinSetFunction(3, GPIO_PIN_PC7, 9); //i2c5_scl_m0
-    GpioPinSetFunction(3, GPIO_PIN_PD0, 9); //i2c5_sda_m0
+    GpioPinSetFunction(1, GPIO_PIN_PB6, 9); //i2c5_scl_m3
+    GpioPinSetFunction(1, GPIO_PIN_PB7, 9); //i2c5_sda_m3
     break;
   case 6:
     GpioPinSetFunction(0, GPIO_PIN_PD0, 9); //i2c6_scl_m0

--- a/edk2-rockchip/Platform/FriendlyElec/NanoPC-T6/Library/RockchipPlatformLib/RockchipPlatformLib.c
+++ b/edk2-rockchip/Platform/FriendlyElec/NanoPC-T6/Library/RockchipPlatformLib/RockchipPlatformLib.c
@@ -164,34 +164,36 @@ I2cIomux (
 {
   switch (id) {
   case 0:
-    /* io mux M2 */
-    PMU2_IOC->GPIO0D_IOMUX_SEL_L = (0x0F00UL << 16) | 0x0300;
-    PMU2_IOC->GPIO0D_IOMUX_SEL_L = (0x00F0UL << 16) | 0x0030;
+    GpioPinSetFunction(0, GPIO_PIN_PB3, 2); //i2c0_scl_m0
+    GpioPinSetFunction(0, GPIO_PIN_PA6, 2); //i2c0_sda_m0
     break;
   case 1:
-    /* io mux */
-    //BUS_IOC->GPIO0B_IOMUX_SEL_H = (0x0FF0UL << 16) | 0x0990;
-    //PMU2_IOC->GPIO0B_IOMUX_SEL_H = (0x0FF0UL << 16) | 0x0880;
+    GpioPinSetFunction(0, GPIO_PIN_PB5, 9); //i2c1_scl_m0
+    GpioPinSetFunction(0, GPIO_PIN_PB6, 9); //i2c1_sda_m0
     break;
   case 2:
-    /* io mux */
-    BUS_IOC->GPIO0B_IOMUX_SEL_H = (0xF000UL << 16) | 0x9000;
-    BUS_IOC->GPIO0C_IOMUX_SEL_L = (0x000FUL << 16) | 0x0009;
-    PMU2_IOC->GPIO0B_IOMUX_SEL_H = (0xF000UL << 16) | 0x8000;
-    PMU2_IOC->GPIO0C_IOMUX_SEL_L = (0x000FUL << 16) | 0x0008;
+    GpioPinSetFunction(0, GPIO_PIN_PB7, 9); //i2c2_scl_m0
+    GpioPinSetFunction(0, GPIO_PIN_PC0, 9); //i2c2_sda_m0
     break;
   case 3:
+    GpioPinSetFunction(1, GPIO_PIN_PC1, 9); //i2c3_scl_m0
+    GpioPinSetFunction(1, GPIO_PIN_PC0, 9); //i2c3_sda_m0
     break;
   case 4:
+    GpioPinSetFunction(3, GPIO_PIN_PA6, 9); //i2c4_scl_m0
+    GpioPinSetFunction(3, GPIO_PIN_PA5, 9); //i2c4_sda_m0
     break;
   case 5:
+    GpioPinSetFunction(3, GPIO_PIN_PC7, 9); //i2c5_scl_m0
+    GpioPinSetFunction(3, GPIO_PIN_PD0, 9); //i2c5_sda_m0
     break;
   case 6:
-    /* io mux M0 */
-    BUS_IOC->GPIO0C_IOMUX_SEL_H = (0xF000UL << 16) | 0x9000;
-    BUS_IOC->GPIO0D_IOMUX_SEL_L = (0x000FUL << 16) | 0x0009;
-    PMU2_IOC->GPIO0C_IOMUX_SEL_H = (0xF000UL << 16) | 0x8000;
-    PMU2_IOC->GPIO0D_IOMUX_SEL_L = (0x000FUL << 16) | 0x0008;
+    GpioPinSetFunction(0, GPIO_PIN_PD0, 9); //i2c6_scl_m0
+    GpioPinSetFunction(0, GPIO_PIN_PC7, 9); //i2c6_sda_m0
+    break;
+  case 7:
+    GpioPinSetFunction(1, GPIO_PIN_PD0, 9); //i2c7_scl_m0
+    GpioPinSetFunction(1, GPIO_PIN_PD1, 9); //i2c7_sda_m0
     break;
   default:
     break;

--- a/edk2-rockchip/Platform/FriendlyElec/NanoPi-R6C/Library/RockchipPlatformLib/RockchipPlatformLib.c
+++ b/edk2-rockchip/Platform/FriendlyElec/NanoPi-R6C/Library/RockchipPlatformLib/RockchipPlatformLib.c
@@ -176,34 +176,36 @@ I2cIomux (
 {
   switch (id) {
   case 0:
-    /* io mux M2 */
-    PMU2_IOC->GPIO0D_IOMUX_SEL_L = (0x0F00UL << 16) | 0x0300;
-    PMU2_IOC->GPIO0D_IOMUX_SEL_L = (0x00F0UL << 16) | 0x0030;
+    GpioPinSetFunction(0, GPIO_PIN_PB3, 2); //i2c0_scl_m0
+    GpioPinSetFunction(0, GPIO_PIN_PA6, 2); //i2c0_sda_m0
     break;
   case 1:
-    /* io mux */
-    //BUS_IOC->GPIO0B_IOMUX_SEL_H = (0x0FF0UL << 16) | 0x0990;
-    //PMU2_IOC->GPIO0B_IOMUX_SEL_H = (0x0FF0UL << 16) | 0x0880;
+    GpioPinSetFunction(0, GPIO_PIN_PB5, 9); //i2c1_scl_m0
+    GpioPinSetFunction(0, GPIO_PIN_PB6, 9); //i2c1_sda_m0
     break;
   case 2:
-    /* io mux */
-    BUS_IOC->GPIO0B_IOMUX_SEL_H = (0xF000UL << 16) | 0x9000;
-    BUS_IOC->GPIO0C_IOMUX_SEL_L = (0x000FUL << 16) | 0x0009;
-    PMU2_IOC->GPIO0B_IOMUX_SEL_H = (0xF000UL << 16) | 0x8000;
-    PMU2_IOC->GPIO0C_IOMUX_SEL_L = (0x000FUL << 16) | 0x0008;
+    GpioPinSetFunction(0, GPIO_PIN_PB7, 9); //i2c2_scl_m0
+    GpioPinSetFunction(0, GPIO_PIN_PC0, 9); //i2c2_sda_m0
     break;
   case 3:
+    GpioPinSetFunction(1, GPIO_PIN_PC1, 9); //i2c3_scl_m0
+    GpioPinSetFunction(1, GPIO_PIN_PC0, 9); //i2c3_sda_m0
     break;
   case 4:
+    GpioPinSetFunction(3, GPIO_PIN_PA6, 9); //i2c4_scl_m0
+    GpioPinSetFunction(3, GPIO_PIN_PA5, 9); //i2c4_sda_m0
     break;
   case 5:
+    GpioPinSetFunction(3, GPIO_PIN_PC7, 9); //i2c5_scl_m0
+    GpioPinSetFunction(3, GPIO_PIN_PD0, 9); //i2c5_sda_m0
     break;
   case 6:
-    /* io mux M0 */
-    BUS_IOC->GPIO0C_IOMUX_SEL_H = (0xF000UL << 16) | 0x9000;
-    BUS_IOC->GPIO0D_IOMUX_SEL_L = (0x000FUL << 16) | 0x0009;
-    PMU2_IOC->GPIO0C_IOMUX_SEL_H = (0xF000UL << 16) | 0x8000;
-    PMU2_IOC->GPIO0D_IOMUX_SEL_L = (0x000FUL << 16) | 0x0008;
+    GpioPinSetFunction(0, GPIO_PIN_PD0, 9); //i2c6_scl_m0
+    GpioPinSetFunction(0, GPIO_PIN_PC7, 9); //i2c6_sda_m0
+    break;
+  case 7:
+    GpioPinSetFunction(1, GPIO_PIN_PD0, 9); //i2c7_scl_m0
+    GpioPinSetFunction(1, GPIO_PIN_PD1, 9); //i2c7_sda_m0
     break;
   default:
     break;

--- a/edk2-rockchip/Platform/FriendlyElec/NanoPi-R6C/Library/RockchipPlatformLib/RockchipPlatformLib.c
+++ b/edk2-rockchip/Platform/FriendlyElec/NanoPi-R6C/Library/RockchipPlatformLib/RockchipPlatformLib.c
@@ -176,8 +176,8 @@ I2cIomux (
 {
   switch (id) {
   case 0:
-    GpioPinSetFunction(0, GPIO_PIN_PB3, 2); //i2c0_scl_m0
-    GpioPinSetFunction(0, GPIO_PIN_PA6, 2); //i2c0_sda_m0
+    GpioPinSetFunction(0, GPIO_PIN_PD1, 3); //i2c0_scl_m2
+    GpioPinSetFunction(0, GPIO_PIN_PD2, 3); //i2c0_sda_m2
     break;
   case 1:
     GpioPinSetFunction(0, GPIO_PIN_PB5, 9); //i2c1_scl_m0
@@ -192,12 +192,12 @@ I2cIomux (
     GpioPinSetFunction(1, GPIO_PIN_PC0, 9); //i2c3_sda_m0
     break;
   case 4:
-    GpioPinSetFunction(3, GPIO_PIN_PA6, 9); //i2c4_scl_m0
-    GpioPinSetFunction(3, GPIO_PIN_PA5, 9); //i2c4_sda_m0
+    GpioPinSetFunction(1, GPIO_PIN_PA3, 9); //i2c4_scl_m3
+    GpioPinSetFunction(1, GPIO_PIN_PA2, 9); //i2c4_sda_m3
     break;
   case 5:
-    GpioPinSetFunction(3, GPIO_PIN_PC7, 9); //i2c5_scl_m0
-    GpioPinSetFunction(3, GPIO_PIN_PD0, 9); //i2c5_sda_m0
+    GpioPinSetFunction(1, GPIO_PIN_PB6, 9); //i2c5_scl_m3
+    GpioPinSetFunction(1, GPIO_PIN_PB7, 9); //i2c5_sda_m3
     break;
   case 6:
     GpioPinSetFunction(0, GPIO_PIN_PD0, 9); //i2c6_scl_m0

--- a/edk2-rockchip/Platform/FriendlyElec/NanoPi-R6C/Library/RockchipPlatformLib/RockchipPlatformLib.c
+++ b/edk2-rockchip/Platform/FriendlyElec/NanoPi-R6C/Library/RockchipPlatformLib/RockchipPlatformLib.c
@@ -180,8 +180,6 @@ I2cIomux (
     GpioPinSetFunction(0, GPIO_PIN_PD2, 3); //i2c0_sda_m2
     break;
   case 1:
-    GpioPinSetFunction(0, GPIO_PIN_PB5, 9); //i2c1_scl_m0
-    GpioPinSetFunction(0, GPIO_PIN_PB6, 9); //i2c1_sda_m0
     break;
   case 2:
     GpioPinSetFunction(0, GPIO_PIN_PB7, 9); //i2c2_scl_m0
@@ -192,20 +190,14 @@ I2cIomux (
     GpioPinSetFunction(1, GPIO_PIN_PC0, 9); //i2c3_sda_m0
     break;
   case 4:
-    GpioPinSetFunction(1, GPIO_PIN_PA3, 9); //i2c4_scl_m3
-    GpioPinSetFunction(1, GPIO_PIN_PA2, 9); //i2c4_sda_m3
     break;
   case 5:
-    GpioPinSetFunction(1, GPIO_PIN_PB6, 9); //i2c5_scl_m3
-    GpioPinSetFunction(1, GPIO_PIN_PB7, 9); //i2c5_sda_m3
     break;
   case 6:
     GpioPinSetFunction(0, GPIO_PIN_PD0, 9); //i2c6_scl_m0
     GpioPinSetFunction(0, GPIO_PIN_PC7, 9); //i2c6_sda_m0
     break;
   case 7:
-    GpioPinSetFunction(1, GPIO_PIN_PD0, 9); //i2c7_scl_m0
-    GpioPinSetFunction(1, GPIO_PIN_PD1, 9); //i2c7_sda_m0
     break;
   default:
     break;

--- a/edk2-rockchip/Platform/FriendlyElec/NanoPi-R6S/Library/RockchipPlatformLib/RockchipPlatformLib.c
+++ b/edk2-rockchip/Platform/FriendlyElec/NanoPi-R6S/Library/RockchipPlatformLib/RockchipPlatformLib.c
@@ -178,8 +178,6 @@ I2cIomux (
     GpioPinSetFunction(0, GPIO_PIN_PD2, 3); //i2c0_sda_m2
     break;
   case 1:
-    GpioPinSetFunction(0, GPIO_PIN_PB5, 9); //i2c1_scl_m0
-    GpioPinSetFunction(0, GPIO_PIN_PB6, 9); //i2c1_sda_m0
     break;
   case 2:
     GpioPinSetFunction(0, GPIO_PIN_PB7, 9); //i2c2_scl_m0
@@ -190,20 +188,14 @@ I2cIomux (
     GpioPinSetFunction(1, GPIO_PIN_PC0, 9); //i2c3_sda_m0
     break;
   case 4:
-    GpioPinSetFunction(1, GPIO_PIN_PA3, 9); //i2c4_scl_m3
-    GpioPinSetFunction(1, GPIO_PIN_PA2, 9); //i2c4_sda_m3
     break;
   case 5:
-    GpioPinSetFunction(1, GPIO_PIN_PB6, 9); //i2c5_scl_m3
-    GpioPinSetFunction(1, GPIO_PIN_PB7, 9); //i2c5_sda_m3
     break;
   case 6:
     GpioPinSetFunction(0, GPIO_PIN_PD0, 9); //i2c6_scl_m0
     GpioPinSetFunction(0, GPIO_PIN_PC7, 9); //i2c6_sda_m0
     break;
   case 7:
-    GpioPinSetFunction(1, GPIO_PIN_PD0, 9); //i2c7_scl_m0
-    GpioPinSetFunction(1, GPIO_PIN_PD1, 9); //i2c7_sda_m0
     break;
   default:
     break;

--- a/edk2-rockchip/Platform/FriendlyElec/NanoPi-R6S/Library/RockchipPlatformLib/RockchipPlatformLib.c
+++ b/edk2-rockchip/Platform/FriendlyElec/NanoPi-R6S/Library/RockchipPlatformLib/RockchipPlatformLib.c
@@ -174,8 +174,8 @@ I2cIomux (
 {
   switch (id) {
   case 0:
-    GpioPinSetFunction(0, GPIO_PIN_PB3, 2); //i2c0_scl_m0
-    GpioPinSetFunction(0, GPIO_PIN_PA6, 2); //i2c0_sda_m0
+    GpioPinSetFunction(0, GPIO_PIN_PD1, 3); //i2c0_scl_m2
+    GpioPinSetFunction(0, GPIO_PIN_PD2, 3); //i2c0_sda_m2
     break;
   case 1:
     GpioPinSetFunction(0, GPIO_PIN_PB5, 9); //i2c1_scl_m0
@@ -190,12 +190,12 @@ I2cIomux (
     GpioPinSetFunction(1, GPIO_PIN_PC0, 9); //i2c3_sda_m0
     break;
   case 4:
-    GpioPinSetFunction(3, GPIO_PIN_PA6, 9); //i2c4_scl_m0
-    GpioPinSetFunction(3, GPIO_PIN_PA5, 9); //i2c4_sda_m0
+    GpioPinSetFunction(1, GPIO_PIN_PA3, 9); //i2c4_scl_m3
+    GpioPinSetFunction(1, GPIO_PIN_PA2, 9); //i2c4_sda_m3
     break;
   case 5:
-    GpioPinSetFunction(3, GPIO_PIN_PC7, 9); //i2c5_scl_m0
-    GpioPinSetFunction(3, GPIO_PIN_PD0, 9); //i2c5_sda_m0
+    GpioPinSetFunction(1, GPIO_PIN_PB6, 9); //i2c5_scl_m3
+    GpioPinSetFunction(1, GPIO_PIN_PB7, 9); //i2c5_sda_m3
     break;
   case 6:
     GpioPinSetFunction(0, GPIO_PIN_PD0, 9); //i2c6_scl_m0

--- a/edk2-rockchip/Platform/FriendlyElec/NanoPi-R6S/Library/RockchipPlatformLib/RockchipPlatformLib.c
+++ b/edk2-rockchip/Platform/FriendlyElec/NanoPi-R6S/Library/RockchipPlatformLib/RockchipPlatformLib.c
@@ -174,34 +174,36 @@ I2cIomux (
 {
   switch (id) {
   case 0:
-    /* io mux M2 */
-    PMU2_IOC->GPIO0D_IOMUX_SEL_L = (0x0F00UL << 16) | 0x0300;
-    PMU2_IOC->GPIO0D_IOMUX_SEL_L = (0x00F0UL << 16) | 0x0030;
+    GpioPinSetFunction(0, GPIO_PIN_PB3, 2); //i2c0_scl_m0
+    GpioPinSetFunction(0, GPIO_PIN_PA6, 2); //i2c0_sda_m0
     break;
   case 1:
-    /* io mux */
-    //BUS_IOC->GPIO0B_IOMUX_SEL_H = (0x0FF0UL << 16) | 0x0990;
-    //PMU2_IOC->GPIO0B_IOMUX_SEL_H = (0x0FF0UL << 16) | 0x0880;
+    GpioPinSetFunction(0, GPIO_PIN_PB5, 9); //i2c1_scl_m0
+    GpioPinSetFunction(0, GPIO_PIN_PB6, 9); //i2c1_sda_m0
     break;
   case 2:
-    /* io mux */
-    BUS_IOC->GPIO0B_IOMUX_SEL_H = (0xF000UL << 16) | 0x9000;
-    BUS_IOC->GPIO0C_IOMUX_SEL_L = (0x000FUL << 16) | 0x0009;
-    PMU2_IOC->GPIO0B_IOMUX_SEL_H = (0xF000UL << 16) | 0x8000;
-    PMU2_IOC->GPIO0C_IOMUX_SEL_L = (0x000FUL << 16) | 0x0008;
+    GpioPinSetFunction(0, GPIO_PIN_PB7, 9); //i2c2_scl_m0
+    GpioPinSetFunction(0, GPIO_PIN_PC0, 9); //i2c2_sda_m0
     break;
   case 3:
+    GpioPinSetFunction(1, GPIO_PIN_PC1, 9); //i2c3_scl_m0
+    GpioPinSetFunction(1, GPIO_PIN_PC0, 9); //i2c3_sda_m0
     break;
   case 4:
+    GpioPinSetFunction(3, GPIO_PIN_PA6, 9); //i2c4_scl_m0
+    GpioPinSetFunction(3, GPIO_PIN_PA5, 9); //i2c4_sda_m0
     break;
   case 5:
+    GpioPinSetFunction(3, GPIO_PIN_PC7, 9); //i2c5_scl_m0
+    GpioPinSetFunction(3, GPIO_PIN_PD0, 9); //i2c5_sda_m0
     break;
   case 6:
-    /* io mux M0 */
-    BUS_IOC->GPIO0C_IOMUX_SEL_H = (0xF000UL << 16) | 0x9000;
-    BUS_IOC->GPIO0D_IOMUX_SEL_L = (0x000FUL << 16) | 0x0009;
-    PMU2_IOC->GPIO0C_IOMUX_SEL_H = (0xF000UL << 16) | 0x8000;
-    PMU2_IOC->GPIO0D_IOMUX_SEL_L = (0x000FUL << 16) | 0x0008;
+    GpioPinSetFunction(0, GPIO_PIN_PD0, 9); //i2c6_scl_m0
+    GpioPinSetFunction(0, GPIO_PIN_PC7, 9); //i2c6_sda_m0
+    break;
+  case 7:
+    GpioPinSetFunction(1, GPIO_PIN_PD0, 9); //i2c7_scl_m0
+    GpioPinSetFunction(1, GPIO_PIN_PD1, 9); //i2c7_sda_m0
     break;
   default:
     break;

--- a/edk2-rockchip/Platform/Hinlink/H88K/Library/RockchipPlatformLib/RockchipPlatformLib.c
+++ b/edk2-rockchip/Platform/Hinlink/H88K/Library/RockchipPlatformLib/RockchipPlatformLib.c
@@ -197,27 +197,36 @@ I2cIomux (
 {
   switch (id) {
   case 0:
-    /* io mux M2 */
-    PMU2_IOC->GPIO0D_IOMUX_SEL_L = (0x0F00UL << 16) | 0x0300;
-    PMU2_IOC->GPIO0D_IOMUX_SEL_L = (0x00F0UL << 16) | 0x0030;
+    GpioPinSetFunction(0, GPIO_PIN_PB3, 2); //i2c0_scl_m0
+    GpioPinSetFunction(0, GPIO_PIN_PA6, 2); //i2c0_sda_m0
     break;
   case 1:
-    /* io mux */
-    //BUS_IOC->GPIO0B_IOMUX_SEL_H = (0x0FF0UL << 16) | 0x0990;
-    //PMU2_IOC->GPIO0B_IOMUX_SEL_H = (0x0FF0UL << 16) | 0x0880;
+    GpioPinSetFunction(0, GPIO_PIN_PB5, 9); //i2c1_scl_m0
+    GpioPinSetFunction(0, GPIO_PIN_PB6, 9); //i2c1_sda_m0
     break;
   case 2:
-    /* io mux */
-    BUS_IOC->GPIO0B_IOMUX_SEL_H = (0xF000UL << 16) | 0x9000;
-    BUS_IOC->GPIO0C_IOMUX_SEL_L = (0x000FUL << 16) | 0x0009;
-    PMU2_IOC->GPIO0B_IOMUX_SEL_H = (0xF000UL << 16) | 0x8000;
-    PMU2_IOC->GPIO0C_IOMUX_SEL_L = (0x000FUL << 16) | 0x0008;
+    GpioPinSetFunction(0, GPIO_PIN_PB7, 9); //i2c2_scl_m0
+    GpioPinSetFunction(0, GPIO_PIN_PC0, 9); //i2c2_sda_m0
     break;
   case 3:
+    GpioPinSetFunction(1, GPIO_PIN_PC1, 9); //i2c3_scl_m0
+    GpioPinSetFunction(1, GPIO_PIN_PC0, 9); //i2c3_sda_m0
     break;
   case 4:
+    GpioPinSetFunction(3, GPIO_PIN_PA6, 9); //i2c4_scl_m0
+    GpioPinSetFunction(3, GPIO_PIN_PA5, 9); //i2c4_sda_m0
     break;
   case 5:
+    GpioPinSetFunction(3, GPIO_PIN_PC7, 9); //i2c5_scl_m0
+    GpioPinSetFunction(3, GPIO_PIN_PD0, 9); //i2c5_sda_m0
+    break;
+  case 6:
+    GpioPinSetFunction(0, GPIO_PIN_PD0, 9); //i2c6_scl_m0
+    GpioPinSetFunction(0, GPIO_PIN_PC7, 9); //i2c6_sda_m0
+    break;
+  case 7:
+    GpioPinSetFunction(1, GPIO_PIN_PD0, 9); //i2c7_scl_m0
+    GpioPinSetFunction(1, GPIO_PIN_PD1, 9); //i2c7_sda_m0
     break;
   default:
     break;

--- a/edk2-rockchip/Platform/Hinlink/H88K/Library/RockchipPlatformLib/RockchipPlatformLib.c
+++ b/edk2-rockchip/Platform/Hinlink/H88K/Library/RockchipPlatformLib/RockchipPlatformLib.c
@@ -197,8 +197,8 @@ I2cIomux (
 {
   switch (id) {
   case 0:
-    GpioPinSetFunction(0, GPIO_PIN_PB3, 2); //i2c0_scl_m0
-    GpioPinSetFunction(0, GPIO_PIN_PA6, 2); //i2c0_sda_m0
+    GpioPinSetFunction(0, GPIO_PIN_PD1, 3); //i2c0_scl_m2
+    GpioPinSetFunction(0, GPIO_PIN_PD2, 3); //i2c0_sda_m2
     break;
   case 1:
     GpioPinSetFunction(0, GPIO_PIN_PB5, 9); //i2c1_scl_m0

--- a/edk2-rockchip/Platform/Khadas/Edge2/Library/RockchipPlatformLib/RockchipPlatformLib.c
+++ b/edk2-rockchip/Platform/Khadas/Edge2/Library/RockchipPlatformLib/RockchipPlatformLib.c
@@ -179,8 +179,6 @@ I2cIomux (
     GpioPinSetFunction(0, GPIO_PIN_PD2, 3); //i2c0_sda_m2
     break;
   case 1:
-    GpioPinSetFunction(0, GPIO_PIN_PB5, 9); //i2c1_scl_m0
-    GpioPinSetFunction(0, GPIO_PIN_PB6, 9); //i2c1_sda_m0
     break;
   case 2:
     GpioPinSetFunction(0, GPIO_PIN_PB7, 9); //i2c2_scl_m0
@@ -195,16 +193,12 @@ I2cIomux (
     GpioPinSetFunction(1, GPIO_PIN_PA2, 9); //i2c4_sda_m3
     break;
   case 5:
-    GpioPinSetFunction(3, GPIO_PIN_PC7, 9); //i2c5_scl_m0
-    GpioPinSetFunction(3, GPIO_PIN_PD0, 9); //i2c5_sda_m0
     break;
   case 6:
     GpioPinSetFunction(0, GPIO_PIN_PD0, 9); //i2c6_scl_m0
     GpioPinSetFunction(0, GPIO_PIN_PC7, 9); //i2c6_sda_m0
     break;
   case 7:
-    GpioPinSetFunction(1, GPIO_PIN_PD0, 9); //i2c7_scl_m0
-    GpioPinSetFunction(1, GPIO_PIN_PD1, 9); //i2c7_sda_m0
     break;
   default:
     break;

--- a/edk2-rockchip/Platform/Khadas/Edge2/Library/RockchipPlatformLib/RockchipPlatformLib.c
+++ b/edk2-rockchip/Platform/Khadas/Edge2/Library/RockchipPlatformLib/RockchipPlatformLib.c
@@ -175,27 +175,36 @@ I2cIomux (
 {
   switch (id) {
   case 0:
-    /* io mux M2 */
-    PMU2_IOC->GPIO0D_IOMUX_SEL_L = (0x0F00UL << 16) | 0x0300;
-    PMU2_IOC->GPIO0D_IOMUX_SEL_L = (0x00F0UL << 16) | 0x0030;
+    GpioPinSetFunction(0, GPIO_PIN_PB3, 2); //i2c0_scl_m0
+    GpioPinSetFunction(0, GPIO_PIN_PA6, 2); //i2c0_sda_m0
     break;
   case 1:
-    /* io mux */
-    //BUS_IOC->GPIO0B_IOMUX_SEL_H = (0x0FF0UL << 16) | 0x0990;
-    //PMU2_IOC->GPIO0B_IOMUX_SEL_H = (0x0FF0UL << 16) | 0x0880;
+    GpioPinSetFunction(0, GPIO_PIN_PB5, 9); //i2c1_scl_m0
+    GpioPinSetFunction(0, GPIO_PIN_PB6, 9); //i2c1_sda_m0
     break;
   case 2:
-    /* io mux */
-    BUS_IOC->GPIO0B_IOMUX_SEL_H = (0xF000UL << 16) | 0x9000;
-    BUS_IOC->GPIO0C_IOMUX_SEL_L = (0x000FUL << 16) | 0x0009;
-    PMU2_IOC->GPIO0B_IOMUX_SEL_H = (0xF000UL << 16) | 0x8000;
-    PMU2_IOC->GPIO0C_IOMUX_SEL_L = (0x000FUL << 16) | 0x0008;
+    GpioPinSetFunction(0, GPIO_PIN_PB7, 9); //i2c2_scl_m0
+    GpioPinSetFunction(0, GPIO_PIN_PC0, 9); //i2c2_sda_m0
     break;
   case 3:
+    GpioPinSetFunction(1, GPIO_PIN_PC1, 9); //i2c3_scl_m0
+    GpioPinSetFunction(1, GPIO_PIN_PC0, 9); //i2c3_sda_m0
     break;
   case 4:
+    GpioPinSetFunction(3, GPIO_PIN_PA6, 9); //i2c4_scl_m0
+    GpioPinSetFunction(3, GPIO_PIN_PA5, 9); //i2c4_sda_m0
     break;
   case 5:
+    GpioPinSetFunction(3, GPIO_PIN_PC7, 9); //i2c5_scl_m0
+    GpioPinSetFunction(3, GPIO_PIN_PD0, 9); //i2c5_sda_m0
+    break;
+  case 6:
+    GpioPinSetFunction(0, GPIO_PIN_PD0, 9); //i2c6_scl_m0
+    GpioPinSetFunction(0, GPIO_PIN_PC7, 9); //i2c6_sda_m0
+    break;
+  case 7:
+    GpioPinSetFunction(1, GPIO_PIN_PD0, 9); //i2c7_scl_m0
+    GpioPinSetFunction(1, GPIO_PIN_PD1, 9); //i2c7_sda_m0
     break;
   default:
     break;

--- a/edk2-rockchip/Platform/Khadas/Edge2/Library/RockchipPlatformLib/RockchipPlatformLib.c
+++ b/edk2-rockchip/Platform/Khadas/Edge2/Library/RockchipPlatformLib/RockchipPlatformLib.c
@@ -175,8 +175,8 @@ I2cIomux (
 {
   switch (id) {
   case 0:
-    GpioPinSetFunction(0, GPIO_PIN_PB3, 2); //i2c0_scl_m0
-    GpioPinSetFunction(0, GPIO_PIN_PA6, 2); //i2c0_sda_m0
+    GpioPinSetFunction(0, GPIO_PIN_PD1, 3); //i2c0_scl_m2
+    GpioPinSetFunction(0, GPIO_PIN_PD2, 3); //i2c0_sda_m2
     break;
   case 1:
     GpioPinSetFunction(0, GPIO_PIN_PB5, 9); //i2c1_scl_m0
@@ -191,8 +191,8 @@ I2cIomux (
     GpioPinSetFunction(1, GPIO_PIN_PC0, 9); //i2c3_sda_m0
     break;
   case 4:
-    GpioPinSetFunction(3, GPIO_PIN_PA6, 9); //i2c4_scl_m0
-    GpioPinSetFunction(3, GPIO_PIN_PA5, 9); //i2c4_sda_m0
+    GpioPinSetFunction(1, GPIO_PIN_PA3, 9); //i2c4_scl_m3
+    GpioPinSetFunction(1, GPIO_PIN_PA2, 9); //i2c4_sda_m3
     break;
   case 5:
     GpioPinSetFunction(3, GPIO_PIN_PC7, 9); //i2c5_scl_m0

--- a/edk2-rockchip/Platform/Mekotronics/R58-Mini/Library/RockchipPlatformLib/RockchipPlatformLib.c
+++ b/edk2-rockchip/Platform/Mekotronics/R58-Mini/Library/RockchipPlatformLib/RockchipPlatformLib.c
@@ -200,20 +200,14 @@ I2cIomux (
     GpioPinSetFunction(0, GPIO_PIN_PD2, 2); //i2c0_sda_m2
     break;
   case 1:
-    GpioPinSetFunction(0, GPIO_PIN_PB5, 9); //i2c1_scl_m0
-    GpioPinSetFunction(0, GPIO_PIN_PB6, 9); //i2c1_sda_m0
     break;
   case 2:
     GpioPinSetFunction(0, GPIO_PIN_PB7, 9); //i2c2_scl_m0
     GpioPinSetFunction(0, GPIO_PIN_PC0, 9); //i2c2_sda_m0
     break;
   case 3:
-    GpioPinSetFunction(1, GPIO_PIN_PC1, 9); //i2c3_scl_m0
-    GpioPinSetFunction(1, GPIO_PIN_PC0, 9); //i2c3_sda_m0
     break;
   case 4:
-    GpioPinSetFunction(3, GPIO_PIN_PA6, 9); //i2c4_scl_m0
-    GpioPinSetFunction(3, GPIO_PIN_PA5, 9); //i2c4_sda_m0
     break;
   case 5:
     GpioPinSetFunction(1, GPIO_PIN_PB6, 9); //i2c5_scl_m3
@@ -224,8 +218,6 @@ I2cIomux (
     GpioPinSetFunction(0, GPIO_PIN_PC7, 9); //i2c6_sda_m0
     break;
   case 7:
-    GpioPinSetFunction(1, GPIO_PIN_PD0, 9); //i2c7_scl_m0
-    GpioPinSetFunction(1, GPIO_PIN_PD1, 9); //i2c7_sda_m0
     break;
   default:
     break;

--- a/edk2-rockchip/Platform/Mekotronics/R58-Mini/Library/RockchipPlatformLib/RockchipPlatformLib.c
+++ b/edk2-rockchip/Platform/Mekotronics/R58-Mini/Library/RockchipPlatformLib/RockchipPlatformLib.c
@@ -196,8 +196,8 @@ I2cIomux (
 {
   switch (id) {
   case 0:
-    GpioPinSetFunction(0, GPIO_PIN_PB3, 2); //i2c0_scl_m0
-    GpioPinSetFunction(0, GPIO_PIN_PA6, 2); //i2c0_sda_m0
+    GpioPinSetFunction(0, GPIO_PIN_PD1, 3); //i2c0_scl_m2
+    GpioPinSetFunction(0, GPIO_PIN_PD2, 2); //i2c0_sda_m2
     break;
   case 1:
     GpioPinSetFunction(0, GPIO_PIN_PB5, 9); //i2c1_scl_m0
@@ -216,8 +216,8 @@ I2cIomux (
     GpioPinSetFunction(3, GPIO_PIN_PA5, 9); //i2c4_sda_m0
     break;
   case 5:
-    GpioPinSetFunction(3, GPIO_PIN_PC7, 9); //i2c5_scl_m0
-    GpioPinSetFunction(3, GPIO_PIN_PD0, 9); //i2c5_sda_m0
+    GpioPinSetFunction(1, GPIO_PIN_PB6, 9); //i2c5_scl_m3
+    GpioPinSetFunction(1, GPIO_PIN_PB7, 9); //i2c5_sda_m3
     break;
   case 6:
     GpioPinSetFunction(0, GPIO_PIN_PD0, 9); //i2c6_scl_m0

--- a/edk2-rockchip/Platform/Mekotronics/R58-Mini/Library/RockchipPlatformLib/RockchipPlatformLib.c
+++ b/edk2-rockchip/Platform/Mekotronics/R58-Mini/Library/RockchipPlatformLib/RockchipPlatformLib.c
@@ -196,34 +196,36 @@ I2cIomux (
 {
   switch (id) {
   case 0:
-    /* io mux M2 */
-    PMU2_IOC->GPIO0D_IOMUX_SEL_L = (0x0F00UL << 16) | 0x0300;
-    PMU2_IOC->GPIO0D_IOMUX_SEL_L = (0x00F0UL << 16) | 0x0030;
+    GpioPinSetFunction(0, GPIO_PIN_PB3, 2); //i2c0_scl_m0
+    GpioPinSetFunction(0, GPIO_PIN_PA6, 2); //i2c0_sda_m0
     break;
   case 1:
-    /* io mux */
-    //BUS_IOC->GPIO0B_IOMUX_SEL_H = (0x0FF0UL << 16) | 0x0990;
-    //PMU2_IOC->GPIO0B_IOMUX_SEL_H = (0x0FF0UL << 16) | 0x0880;
+    GpioPinSetFunction(0, GPIO_PIN_PB5, 9); //i2c1_scl_m0
+    GpioPinSetFunction(0, GPIO_PIN_PB6, 9); //i2c1_sda_m0
     break;
   case 2:
-    /* io mux */
-    BUS_IOC->GPIO0B_IOMUX_SEL_H = (0xF000UL << 16) | 0x9000;
-    BUS_IOC->GPIO0C_IOMUX_SEL_L = (0x000FUL << 16) | 0x0009;
-    PMU2_IOC->GPIO0B_IOMUX_SEL_H = (0xF000UL << 16) | 0x8000;
-    PMU2_IOC->GPIO0C_IOMUX_SEL_L = (0x000FUL << 16) | 0x0008;
+    GpioPinSetFunction(0, GPIO_PIN_PB7, 9); //i2c2_scl_m0
+    GpioPinSetFunction(0, GPIO_PIN_PC0, 9); //i2c2_sda_m0
     break;
   case 3:
+    GpioPinSetFunction(1, GPIO_PIN_PC1, 9); //i2c3_scl_m0
+    GpioPinSetFunction(1, GPIO_PIN_PC0, 9); //i2c3_sda_m0
     break;
   case 4:
+    GpioPinSetFunction(3, GPIO_PIN_PA6, 9); //i2c4_scl_m0
+    GpioPinSetFunction(3, GPIO_PIN_PA5, 9); //i2c4_sda_m0
     break;
   case 5:
+    GpioPinSetFunction(3, GPIO_PIN_PC7, 9); //i2c5_scl_m0
+    GpioPinSetFunction(3, GPIO_PIN_PD0, 9); //i2c5_sda_m0
     break;
   case 6:
-    /* io mux M0 */
-    BUS_IOC->GPIO0C_IOMUX_SEL_H = (0xF000UL << 16) | 0x9000;
-    BUS_IOC->GPIO0D_IOMUX_SEL_L = (0x000FUL << 16) | 0x0009;
-    PMU2_IOC->GPIO0C_IOMUX_SEL_H = (0xF000UL << 16) | 0x8000;
-    PMU2_IOC->GPIO0D_IOMUX_SEL_L = (0x000FUL << 16) | 0x0008;
+    GpioPinSetFunction(0, GPIO_PIN_PD0, 9); //i2c6_scl_m0
+    GpioPinSetFunction(0, GPIO_PIN_PC7, 9); //i2c6_sda_m0
+    break;
+  case 7:
+    GpioPinSetFunction(1, GPIO_PIN_PD0, 9); //i2c7_scl_m0
+    GpioPinSetFunction(1, GPIO_PIN_PD1, 9); //i2c7_sda_m0
     break;
   default:
     break;

--- a/edk2-rockchip/Platform/Mekotronics/R58X/Library/RockchipPlatformLib/RockchipPlatformLib.c
+++ b/edk2-rockchip/Platform/Mekotronics/R58X/Library/RockchipPlatformLib/RockchipPlatformLib.c
@@ -211,8 +211,8 @@ I2cIomux (
 {
   switch (id) {
   case 0:
-    GpioPinSetFunction(0, GPIO_PIN_PB3, 2); //i2c0_scl_m0
-    GpioPinSetFunction(0, GPIO_PIN_PA6, 2); //i2c0_sda_m0
+    GpioPinSetFunction(0, GPIO_PIN_PD1, 3); //i2c0_scl_m2
+    GpioPinSetFunction(0, GPIO_PIN_PD2, 2); //i2c0_sda_m2
     break;
   case 1:
     GpioPinSetFunction(0, GPIO_PIN_PB5, 9); //i2c1_scl_m0
@@ -231,8 +231,8 @@ I2cIomux (
     GpioPinSetFunction(3, GPIO_PIN_PA5, 9); //i2c4_sda_m0
     break;
   case 5:
-    GpioPinSetFunction(3, GPIO_PIN_PC7, 9); //i2c5_scl_m0
-    GpioPinSetFunction(3, GPIO_PIN_PD0, 9); //i2c5_sda_m0
+    GpioPinSetFunction(1, GPIO_PIN_PB6, 9); //i2c5_scl_m3
+    GpioPinSetFunction(1, GPIO_PIN_PB7, 9); //i2c5_sda_m3
     break;
   case 6:
     GpioPinSetFunction(0, GPIO_PIN_PD0, 9); //i2c6_scl_m0

--- a/edk2-rockchip/Platform/Mekotronics/R58X/Library/RockchipPlatformLib/RockchipPlatformLib.c
+++ b/edk2-rockchip/Platform/Mekotronics/R58X/Library/RockchipPlatformLib/RockchipPlatformLib.c
@@ -215,8 +215,6 @@ I2cIomux (
     GpioPinSetFunction(0, GPIO_PIN_PD2, 2); //i2c0_sda_m2
     break;
   case 1:
-    GpioPinSetFunction(0, GPIO_PIN_PB5, 9); //i2c1_scl_m0
-    GpioPinSetFunction(0, GPIO_PIN_PB6, 9); //i2c1_sda_m0
     break;
   case 2:
     GpioPinSetFunction(0, GPIO_PIN_PB7, 9); //i2c2_scl_m0
@@ -227,8 +225,6 @@ I2cIomux (
     GpioPinSetFunction(1, GPIO_PIN_PC0, 9); //i2c3_sda_m0
     break;
   case 4:
-    GpioPinSetFunction(3, GPIO_PIN_PA6, 9); //i2c4_scl_m0
-    GpioPinSetFunction(3, GPIO_PIN_PA5, 9); //i2c4_sda_m0
     break;
   case 5:
     GpioPinSetFunction(1, GPIO_PIN_PB6, 9); //i2c5_scl_m3
@@ -239,8 +235,6 @@ I2cIomux (
     GpioPinSetFunction(0, GPIO_PIN_PC7, 9); //i2c6_sda_m0
     break;
   case 7:
-    GpioPinSetFunction(1, GPIO_PIN_PD0, 9); //i2c7_scl_m0
-    GpioPinSetFunction(1, GPIO_PIN_PD1, 9); //i2c7_sda_m0
     break;
   default:
     break;

--- a/edk2-rockchip/Platform/Mekotronics/R58X/Library/RockchipPlatformLib/RockchipPlatformLib.c
+++ b/edk2-rockchip/Platform/Mekotronics/R58X/Library/RockchipPlatformLib/RockchipPlatformLib.c
@@ -211,34 +211,37 @@ I2cIomux (
 {
   switch (id) {
   case 0:
-    /* io mux M2 */
-    PMU2_IOC->GPIO0D_IOMUX_SEL_L = (0x0F00UL << 16) | 0x0300;
-    PMU2_IOC->GPIO0D_IOMUX_SEL_L = (0x00F0UL << 16) | 0x0030;
+    GpioPinSetFunction(0, GPIO_PIN_PB3, 2); //i2c0_scl_m0
+    GpioPinSetFunction(0, GPIO_PIN_PA6, 2); //i2c0_sda_m0
     break;
   case 1:
-    /* io mux */
-    //BUS_IOC->GPIO0B_IOMUX_SEL_H = (0x0FF0UL << 16) | 0x0990;
-    //PMU2_IOC->GPIO0B_IOMUX_SEL_H = (0x0FF0UL << 16) | 0x0880;
+    GpioPinSetFunction(0, GPIO_PIN_PB5, 9); //i2c1_scl_m0
+    GpioPinSetFunction(0, GPIO_PIN_PB6, 9); //i2c1_sda_m0
     break;
   case 2:
-    /* io mux */
-    BUS_IOC->GPIO0B_IOMUX_SEL_H = (0xF000UL << 16) | 0x9000;
-    BUS_IOC->GPIO0C_IOMUX_SEL_L = (0x000FUL << 16) | 0x0009;
-    PMU2_IOC->GPIO0B_IOMUX_SEL_H = (0xF000UL << 16) | 0x8000;
-    PMU2_IOC->GPIO0C_IOMUX_SEL_L = (0x000FUL << 16) | 0x0008;
+    GpioPinSetFunction(0, GPIO_PIN_PB7, 9); //i2c2_scl_m0
+    GpioPinSetFunction(0, GPIO_PIN_PC0, 9); //i2c2_sda_m0
     break;
   case 3:
+    GpioPinSetFunction(1, GPIO_PIN_PC1, 9); //i2c3_scl_m0
+    GpioPinSetFunction(1, GPIO_PIN_PC0, 9); //i2c3_sda_m0
     break;
   case 4:
+    GpioPinSetFunction(3, GPIO_PIN_PA6, 9); //i2c4_scl_m0
+    GpioPinSetFunction(3, GPIO_PIN_PA5, 9); //i2c4_sda_m0
     break;
   case 5:
+    GpioPinSetFunction(3, GPIO_PIN_PC7, 9); //i2c5_scl_m0
+    GpioPinSetFunction(3, GPIO_PIN_PD0, 9); //i2c5_sda_m0
     break;
   case 6:
-    /* io mux M0 */
-    BUS_IOC->GPIO0C_IOMUX_SEL_H = (0xF000UL << 16) | 0x9000;
-    BUS_IOC->GPIO0D_IOMUX_SEL_L = (0x000FUL << 16) | 0x0009;
-    PMU2_IOC->GPIO0C_IOMUX_SEL_H = (0xF000UL << 16) | 0x8000;
-    PMU2_IOC->GPIO0D_IOMUX_SEL_L = (0x000FUL << 16) | 0x0008;
+    GpioPinSetFunction(0, GPIO_PIN_PD0, 9); //i2c6_scl_m0
+    GpioPinSetFunction(0, GPIO_PIN_PC7, 9); //i2c6_sda_m0
+    break;
+  case 7:
+    GpioPinSetFunction(1, GPIO_PIN_PD0, 9); //i2c7_scl_m0
+    GpioPinSetFunction(1, GPIO_PIN_PD1, 9); //i2c7_sda_m0
+    break;
   default:
     break;
   }

--- a/edk2-rockchip/Platform/Mixtile/Blade3/Library/RockchipPlatformLib/RockchipPlatformLib.c
+++ b/edk2-rockchip/Platform/Mixtile/Blade3/Library/RockchipPlatformLib/RockchipPlatformLib.c
@@ -165,27 +165,36 @@ I2cIomux (
 {
   switch (id) {
   case 0:
-    /* io mux M2 */
-    PMU2_IOC->GPIO0D_IOMUX_SEL_L = (0x0F00UL << 16) | 0x0300;
-    PMU2_IOC->GPIO0D_IOMUX_SEL_L = (0x00F0UL << 16) | 0x0030;
+    GpioPinSetFunction(0, GPIO_PIN_PB3, 2); //i2c0_scl_m0
+    GpioPinSetFunction(0, GPIO_PIN_PA6, 2); //i2c0_sda_m0
     break;
   case 1:
-    /* io mux */
-    //BUS_IOC->GPIO0B_IOMUX_SEL_H = (0x0FF0UL << 16) | 0x0990;
-    //PMU2_IOC->GPIO0B_IOMUX_SEL_H = (0x0FF0UL << 16) | 0x0880;
+    GpioPinSetFunction(0, GPIO_PIN_PB5, 9); //i2c1_scl_m0
+    GpioPinSetFunction(0, GPIO_PIN_PB6, 9); //i2c1_sda_m0
     break;
   case 2:
-    /* io mux */
-    BUS_IOC->GPIO0B_IOMUX_SEL_H = (0xF000UL << 16) | 0x9000;
-    BUS_IOC->GPIO0C_IOMUX_SEL_L = (0x000FUL << 16) | 0x0009;
-    PMU2_IOC->GPIO0B_IOMUX_SEL_H = (0xF000UL << 16) | 0x8000;
-    PMU2_IOC->GPIO0C_IOMUX_SEL_L = (0x000FUL << 16) | 0x0008;
+    GpioPinSetFunction(0, GPIO_PIN_PB7, 9); //i2c2_scl_m0
+    GpioPinSetFunction(0, GPIO_PIN_PC0, 9); //i2c2_sda_m0
     break;
   case 3:
+    GpioPinSetFunction(1, GPIO_PIN_PC1, 9); //i2c3_scl_m0
+    GpioPinSetFunction(1, GPIO_PIN_PC0, 9); //i2c3_sda_m0
     break;
   case 4:
+    GpioPinSetFunction(3, GPIO_PIN_PA6, 9); //i2c4_scl_m0
+    GpioPinSetFunction(3, GPIO_PIN_PA5, 9); //i2c4_sda_m0
     break;
   case 5:
+    GpioPinSetFunction(3, GPIO_PIN_PC7, 9); //i2c5_scl_m0
+    GpioPinSetFunction(3, GPIO_PIN_PD0, 9); //i2c5_sda_m0
+    break;
+  case 6:
+    GpioPinSetFunction(0, GPIO_PIN_PD0, 9); //i2c6_scl_m0
+    GpioPinSetFunction(0, GPIO_PIN_PC7, 9); //i2c6_sda_m0
+    break;
+  case 7:
+    GpioPinSetFunction(1, GPIO_PIN_PD0, 9); //i2c7_scl_m0
+    GpioPinSetFunction(1, GPIO_PIN_PD1, 9); //i2c7_sda_m0
     break;
   default:
     break;

--- a/edk2-rockchip/Platform/Mixtile/Blade3/Library/RockchipPlatformLib/RockchipPlatformLib.c
+++ b/edk2-rockchip/Platform/Mixtile/Blade3/Library/RockchipPlatformLib/RockchipPlatformLib.c
@@ -173,12 +173,8 @@ I2cIomux (
     GpioPinSetFunction(0, GPIO_PIN_PD5, 9); //i2c1_sda_m2
     break;
   case 2:
-    GpioPinSetFunction(0, GPIO_PIN_PB7, 9); //i2c2_scl_m0
-    GpioPinSetFunction(0, GPIO_PIN_PC0, 9); //i2c2_sda_m0
     break;
   case 3:
-    GpioPinSetFunction(1, GPIO_PIN_PC1, 9); //i2c3_scl_m0
-    GpioPinSetFunction(1, GPIO_PIN_PC0, 9); //i2c3_sda_m0
     break;
   case 4:
     GpioPinSetFunction(3, GPIO_PIN_PA6, 9); //i2c4_scl_m0
@@ -193,8 +189,6 @@ I2cIomux (
     GpioPinSetFunction(0, GPIO_PIN_PC7, 9); //i2c6_sda_m0
     break;
   case 7:
-    GpioPinSetFunction(1, GPIO_PIN_PD0, 9); //i2c7_scl_m0
-    GpioPinSetFunction(1, GPIO_PIN_PD1, 9); //i2c7_sda_m0
     break;
   default:
     break;

--- a/edk2-rockchip/Platform/Mixtile/Blade3/Library/RockchipPlatformLib/RockchipPlatformLib.c
+++ b/edk2-rockchip/Platform/Mixtile/Blade3/Library/RockchipPlatformLib/RockchipPlatformLib.c
@@ -165,12 +165,12 @@ I2cIomux (
 {
   switch (id) {
   case 0:
-    GpioPinSetFunction(0, GPIO_PIN_PB3, 2); //i2c0_scl_m0
-    GpioPinSetFunction(0, GPIO_PIN_PA6, 2); //i2c0_sda_m0
+    GpioPinSetFunction(0, GPIO_PIN_PD1, 3); //i2c0_scl_m2
+    GpioPinSetFunction(0, GPIO_PIN_PD2, 3); //i2c0_sda_m2
     break;
   case 1:
-    GpioPinSetFunction(0, GPIO_PIN_PB5, 9); //i2c1_scl_m0
-    GpioPinSetFunction(0, GPIO_PIN_PB6, 9); //i2c1_sda_m0
+    GpioPinSetFunction(0, GPIO_PIN_PD4, 9); //i2c1_scl_m2
+    GpioPinSetFunction(0, GPIO_PIN_PD5, 9); //i2c1_sda_m2
     break;
   case 2:
     GpioPinSetFunction(0, GPIO_PIN_PB7, 9); //i2c2_scl_m0
@@ -185,8 +185,8 @@ I2cIomux (
     GpioPinSetFunction(3, GPIO_PIN_PA5, 9); //i2c4_sda_m0
     break;
   case 5:
-    GpioPinSetFunction(3, GPIO_PIN_PC7, 9); //i2c5_scl_m0
-    GpioPinSetFunction(3, GPIO_PIN_PD0, 9); //i2c5_sda_m0
+    GpioPinSetFunction(1, GPIO_PIN_PB6, 9); //i2c5_scl_m3
+    GpioPinSetFunction(1, GPIO_PIN_PB7, 9); //i2c5_sda_m3
     break;
   case 6:
     GpioPinSetFunction(0, GPIO_PIN_PD0, 9); //i2c6_scl_m0

--- a/edk2-rockchip/Platform/OrangePi/OrangePi5/Library/RockchipPlatformLib/RockchipPlatformLib.c
+++ b/edk2-rockchip/Platform/OrangePi/OrangePi5/Library/RockchipPlatformLib/RockchipPlatformLib.c
@@ -181,24 +181,18 @@ I2cIomux (
     GpioPinSetFunction(0, GPIO_PIN_PA6, 2); //i2c0_sda_m0
     break;
   case 1:
-    GpioPinSetFunction(0, GPIO_PIN_PB5, 9); //i2c1_scl_m0
-    GpioPinSetFunction(0, GPIO_PIN_PB6, 9); //i2c1_sda_m0
     break;
   case 2:
     GpioPinSetFunction(0, GPIO_PIN_PB7, 9); //i2c2_scl_m0
     GpioPinSetFunction(0, GPIO_PIN_PC0, 9); //i2c2_sda_m0
     break;
   case 3:
-    GpioPinSetFunction(1, GPIO_PIN_PC1, 9); //i2c3_scl_m0
-    GpioPinSetFunction(1, GPIO_PIN_PC0, 9); //i2c3_sda_m0
     break;
   case 4:
     GpioPinSetFunction(3, GPIO_PIN_PA6, 9); //i2c4_scl_m0
     GpioPinSetFunction(3, GPIO_PIN_PA5, 9); //i2c4_sda_m0
     break;
   case 5:
-    GpioPinSetFunction(3, GPIO_PIN_PC7, 9); //i2c5_scl_m0
-    GpioPinSetFunction(3, GPIO_PIN_PD0, 9); //i2c5_sda_m0
     break;
   case 6:
     GpioPinSetFunction(4, GPIO_PIN_PB1, 9); //i2c6_scl_m3

--- a/edk2-rockchip/Platform/OrangePi/OrangePi5/Library/RockchipPlatformLib/RockchipPlatformLib.c
+++ b/edk2-rockchip/Platform/OrangePi/OrangePi5/Library/RockchipPlatformLib/RockchipPlatformLib.c
@@ -177,32 +177,36 @@ I2cIomux (
 {
   switch (id) {
   case 0:
-    /* io mux M2 */
-    PMU2_IOC->GPIO0D_IOMUX_SEL_L = (0x0F00UL << 16) | 0x0300;
-    PMU2_IOC->GPIO0D_IOMUX_SEL_L = (0x00F0UL << 16) | 0x0030;
+    GpioPinSetFunction(0, GPIO_PIN_PB3, 2); //i2c0_scl_m0
+    GpioPinSetFunction(0, GPIO_PIN_PA6, 2); //i2c0_sda_m0
     break;
   case 1:
-    /* io mux */
-    //BUS_IOC->GPIO0B_IOMUX_SEL_H = (0x0FF0UL << 16) | 0x0990;
-    //PMU2_IOC->GPIO0B_IOMUX_SEL_H = (0x0FF0UL << 16) | 0x0880;
+    GpioPinSetFunction(0, GPIO_PIN_PB5, 9); //i2c1_scl_m0
+    GpioPinSetFunction(0, GPIO_PIN_PB6, 9); //i2c1_sda_m0
     break;
   case 2:
-    /* io mux */
-    BUS_IOC->GPIO0B_IOMUX_SEL_H = (0xF000UL << 16) | 0x9000;
-    BUS_IOC->GPIO0C_IOMUX_SEL_L = (0x000FUL << 16) | 0x0009;
-    PMU2_IOC->GPIO0B_IOMUX_SEL_H = (0xF000UL << 16) | 0x8000;
-    PMU2_IOC->GPIO0C_IOMUX_SEL_L = (0x000FUL << 16) | 0x0008;
+    GpioPinSetFunction(0, GPIO_PIN_PB7, 9); //i2c2_scl_m0
+    GpioPinSetFunction(0, GPIO_PIN_PC0, 9); //i2c2_sda_m0
     break;
   case 3:
+    GpioPinSetFunction(1, GPIO_PIN_PC1, 9); //i2c3_scl_m0
+    GpioPinSetFunction(1, GPIO_PIN_PC0, 9); //i2c3_sda_m0
     break;
   case 4:
+    GpioPinSetFunction(3, GPIO_PIN_PA6, 9); //i2c4_scl_m0
+    GpioPinSetFunction(3, GPIO_PIN_PA5, 9); //i2c4_sda_m0
     break;
   case 5:
+    GpioPinSetFunction(3, GPIO_PIN_PC7, 9); //i2c5_scl_m0
+    GpioPinSetFunction(3, GPIO_PIN_PD0, 9); //i2c5_sda_m0
     break;
   case 6:
-    /* io mux M3 */
-    BUS_IOC->GPIO4B_IOMUX_SEL_L = (0x00F0UL << 16) | 0x0090;
-    BUS_IOC->GPIO4B_IOMUX_SEL_L = (0x000FUL << 16) | 0x0009;
+    GpioPinSetFunction(0, GPIO_PIN_PD0, 9); //i2c6_scl_m0
+    GpioPinSetFunction(0, GPIO_PIN_PC7, 9); //i2c6_sda_m0
+    break;
+  case 7:
+    GpioPinSetFunction(1, GPIO_PIN_PD0, 9); //i2c7_scl_m0
+    GpioPinSetFunction(1, GPIO_PIN_PD1, 9); //i2c7_sda_m0
     break;
   default:
     break;

--- a/edk2-rockchip/Platform/OrangePi/OrangePi5/Library/RockchipPlatformLib/RockchipPlatformLib.c
+++ b/edk2-rockchip/Platform/OrangePi/OrangePi5/Library/RockchipPlatformLib/RockchipPlatformLib.c
@@ -201,8 +201,8 @@ I2cIomux (
     GpioPinSetFunction(3, GPIO_PIN_PD0, 9); //i2c5_sda_m0
     break;
   case 6:
-    GpioPinSetFunction(0, GPIO_PIN_PD0, 9); //i2c6_scl_m0
-    GpioPinSetFunction(0, GPIO_PIN_PC7, 9); //i2c6_sda_m0
+    GpioPinSetFunction(4, GPIO_PIN_PB1, 9); //i2c6_scl_m3
+    GpioPinSetFunction(4, GPIO_PIN_PB0, 9); //i2c6_sda_m3
     break;
   case 7:
     GpioPinSetFunction(1, GPIO_PIN_PD0, 9); //i2c7_scl_m0

--- a/edk2-rockchip/Platform/OrangePi/OrangePi5Plus/Library/RockchipPlatformLib/RockchipPlatformLib.c
+++ b/edk2-rockchip/Platform/OrangePi/OrangePi5Plus/Library/RockchipPlatformLib/RockchipPlatformLib.c
@@ -165,12 +165,12 @@ I2cIomux (
 {
   switch (id) {
   case 0:
-    GpioPinSetFunction(0, GPIO_PIN_PB3, 2); //i2c0_scl_m0
-    GpioPinSetFunction(0, GPIO_PIN_PA6, 2); //i2c0_sda_m0
+    GpioPinSetFunction(0, GPIO_PIN_PD1, 3); //i2c0_scl_m2
+    GpioPinSetFunction(0, GPIO_PIN_PD2, 3); //i2c0_sda_m2
     break;
   case 1:
-    GpioPinSetFunction(0, GPIO_PIN_PB5, 9); //i2c1_scl_m0
-    GpioPinSetFunction(0, GPIO_PIN_PB6, 9); //i2c1_sda_m0
+    GpioPinSetFunction(0, GPIO_PIN_PD4, 9); //i2c1_scl_m2
+    GpioPinSetFunction(0, GPIO_PIN_PD5, 9); //i2c1_sda_m2
     break;
   case 2:
     GpioPinSetFunction(0, GPIO_PIN_PB7, 9); //i2c2_scl_m0

--- a/edk2-rockchip/Platform/OrangePi/OrangePi5Plus/Library/RockchipPlatformLib/RockchipPlatformLib.c
+++ b/edk2-rockchip/Platform/OrangePi/OrangePi5Plus/Library/RockchipPlatformLib/RockchipPlatformLib.c
@@ -173,20 +173,14 @@ I2cIomux (
     GpioPinSetFunction(0, GPIO_PIN_PD5, 9); //i2c1_sda_m2
     break;
   case 2:
-    GpioPinSetFunction(0, GPIO_PIN_PB7, 9); //i2c2_scl_m0
-    GpioPinSetFunction(0, GPIO_PIN_PC0, 9); //i2c2_sda_m0
     break;
   case 3:
     GpioPinSetFunction(1, GPIO_PIN_PC1, 9); //i2c3_scl_m0
     GpioPinSetFunction(1, GPIO_PIN_PC0, 9); //i2c3_sda_m0
     break;
   case 4:
-    GpioPinSetFunction(3, GPIO_PIN_PA6, 9); //i2c4_scl_m0
-    GpioPinSetFunction(3, GPIO_PIN_PA5, 9); //i2c4_sda_m0
     break;
   case 5:
-    GpioPinSetFunction(3, GPIO_PIN_PC7, 9); //i2c5_scl_m0
-    GpioPinSetFunction(3, GPIO_PIN_PD0, 9); //i2c5_sda_m0
     break;
   case 6:
     GpioPinSetFunction(0, GPIO_PIN_PD0, 9); //i2c6_scl_m0

--- a/edk2-rockchip/Platform/OrangePi/OrangePi5Plus/Library/RockchipPlatformLib/RockchipPlatformLib.c
+++ b/edk2-rockchip/Platform/OrangePi/OrangePi5Plus/Library/RockchipPlatformLib/RockchipPlatformLib.c
@@ -165,34 +165,36 @@ I2cIomux (
 {
   switch (id) {
   case 0:
-    /* io mux M2 */
-    PMU2_IOC->GPIO0D_IOMUX_SEL_L = (0x0F00UL << 16) | 0x0300;
-    PMU2_IOC->GPIO0D_IOMUX_SEL_L = (0x00F0UL << 16) | 0x0030;
+    GpioPinSetFunction(0, GPIO_PIN_PB3, 2); //i2c0_scl_m0
+    GpioPinSetFunction(0, GPIO_PIN_PA6, 2); //i2c0_sda_m0
     break;
   case 1:
-    /* io mux */
-    //BUS_IOC->GPIO0B_IOMUX_SEL_H = (0x0FF0UL << 16) | 0x0990;
-    //PMU2_IOC->GPIO0B_IOMUX_SEL_H = (0x0FF0UL << 16) | 0x0880;
+    GpioPinSetFunction(0, GPIO_PIN_PB5, 9); //i2c1_scl_m0
+    GpioPinSetFunction(0, GPIO_PIN_PB6, 9); //i2c1_sda_m0
     break;
   case 2:
-    /* io mux */
-    BUS_IOC->GPIO0B_IOMUX_SEL_H = (0xF000UL << 16) | 0x9000;
-    BUS_IOC->GPIO0C_IOMUX_SEL_L = (0x000FUL << 16) | 0x0009;
-    PMU2_IOC->GPIO0B_IOMUX_SEL_H = (0xF000UL << 16) | 0x8000;
-    PMU2_IOC->GPIO0C_IOMUX_SEL_L = (0x000FUL << 16) | 0x0008;
+    GpioPinSetFunction(0, GPIO_PIN_PB7, 9); //i2c2_scl_m0
+    GpioPinSetFunction(0, GPIO_PIN_PC0, 9); //i2c2_sda_m0
     break;
   case 3:
+    GpioPinSetFunction(1, GPIO_PIN_PC1, 9); //i2c3_scl_m0
+    GpioPinSetFunction(1, GPIO_PIN_PC0, 9); //i2c3_sda_m0
     break;
   case 4:
+    GpioPinSetFunction(3, GPIO_PIN_PA6, 9); //i2c4_scl_m0
+    GpioPinSetFunction(3, GPIO_PIN_PA5, 9); //i2c4_sda_m0
     break;
   case 5:
+    GpioPinSetFunction(3, GPIO_PIN_PC7, 9); //i2c5_scl_m0
+    GpioPinSetFunction(3, GPIO_PIN_PD0, 9); //i2c5_sda_m0
     break;
   case 6:
-    /* io mux M0 */
-    BUS_IOC->GPIO0C_IOMUX_SEL_H = (0xF000UL << 16) | 0x9000;
-    BUS_IOC->GPIO0D_IOMUX_SEL_L = (0x000FUL << 16) | 0x0009;
-    PMU2_IOC->GPIO0C_IOMUX_SEL_H = (0xF000UL << 16) | 0x8000;
-    PMU2_IOC->GPIO0D_IOMUX_SEL_L = (0x000FUL << 16) | 0x0008;
+    GpioPinSetFunction(0, GPIO_PIN_PD0, 9); //i2c6_scl_m0
+    GpioPinSetFunction(0, GPIO_PIN_PC7, 9); //i2c6_sda_m0
+    break;
+  case 7:
+    GpioPinSetFunction(1, GPIO_PIN_PD0, 9); //i2c7_scl_m0
+    GpioPinSetFunction(1, GPIO_PIN_PD1, 9); //i2c7_sda_m0
     break;
   default:
     break;

--- a/edk2-rockchip/Platform/Radxa/ROCK5A/Library/RockchipPlatformLib/RockchipPlatformLib.c
+++ b/edk2-rockchip/Platform/Radxa/ROCK5A/Library/RockchipPlatformLib/RockchipPlatformLib.c
@@ -179,28 +179,18 @@ I2cIomux (
     GpioPinSetFunction(0, GPIO_PIN_PD2, 3); //i2c0_sda_m2
     break;
   case 1:
-    GpioPinSetFunction(0, GPIO_PIN_PB5, 9); //i2c1_scl_m0
-    GpioPinSetFunction(0, GPIO_PIN_PB6, 9); //i2c1_sda_m0
     break;
   case 2:
     GpioPinSetFunction(0, GPIO_PIN_PB7, 9); //i2c2_scl_m0
     GpioPinSetFunction(0, GPIO_PIN_PC0, 9); //i2c2_sda_m0
     break;
   case 3:
-    GpioPinSetFunction(1, GPIO_PIN_PC1, 9); //i2c3_scl_m0
-    GpioPinSetFunction(1, GPIO_PIN_PC0, 9); //i2c3_sda_m0
     break;
   case 4:
-    GpioPinSetFunction(3, GPIO_PIN_PA6, 9); //i2c4_scl_m0
-    GpioPinSetFunction(3, GPIO_PIN_PA5, 9); //i2c4_sda_m0
     break;
   case 5:
-    GpioPinSetFunction(3, GPIO_PIN_PC7, 9); //i2c5_scl_m0
-    GpioPinSetFunction(3, GPIO_PIN_PD0, 9); //i2c5_sda_m0
     break;
   case 6:
-    GpioPinSetFunction(0, GPIO_PIN_PD0, 9); //i2c6_scl_m0
-    GpioPinSetFunction(0, GPIO_PIN_PC7, 9); //i2c6_sda_m0
     break;
   case 7:
     GpioPinSetFunction(1, GPIO_PIN_PD0, 9); //i2c7_scl_m0

--- a/edk2-rockchip/Platform/Radxa/ROCK5A/Library/RockchipPlatformLib/RockchipPlatformLib.c
+++ b/edk2-rockchip/Platform/Radxa/ROCK5A/Library/RockchipPlatformLib/RockchipPlatformLib.c
@@ -175,27 +175,36 @@ I2cIomux (
 {
   switch (id) {
   case 0:
-    /* io mux M2 */
-    PMU2_IOC->GPIO0D_IOMUX_SEL_L = (0x0F00UL << 16) | 0x0300;
-    PMU2_IOC->GPIO0D_IOMUX_SEL_L = (0x00F0UL << 16) | 0x0030;
+    GpioPinSetFunction(0, GPIO_PIN_PB3, 2); //i2c0_scl_m0
+    GpioPinSetFunction(0, GPIO_PIN_PA6, 2); //i2c0_sda_m0
     break;
   case 1:
-    /* io mux */
-    //BUS_IOC->GPIO0B_IOMUX_SEL_H = (0x0FF0UL << 16) | 0x0990;
-    //PMU2_IOC->GPIO0B_IOMUX_SEL_H = (0x0FF0UL << 16) | 0x0880;
+    GpioPinSetFunction(0, GPIO_PIN_PB5, 9); //i2c1_scl_m0
+    GpioPinSetFunction(0, GPIO_PIN_PB6, 9); //i2c1_sda_m0
     break;
   case 2:
-    /* io mux */
-    BUS_IOC->GPIO0B_IOMUX_SEL_H = (0xF000UL << 16) | 0x9000;
-    BUS_IOC->GPIO0C_IOMUX_SEL_L = (0x000FUL << 16) | 0x0009;
-    PMU2_IOC->GPIO0B_IOMUX_SEL_H = (0xF000UL << 16) | 0x8000;
-    PMU2_IOC->GPIO0C_IOMUX_SEL_L = (0x000FUL << 16) | 0x0008;
+    GpioPinSetFunction(0, GPIO_PIN_PB7, 9); //i2c2_scl_m0
+    GpioPinSetFunction(0, GPIO_PIN_PC0, 9); //i2c2_sda_m0
     break;
   case 3:
+    GpioPinSetFunction(1, GPIO_PIN_PC1, 9); //i2c3_scl_m0
+    GpioPinSetFunction(1, GPIO_PIN_PC0, 9); //i2c3_sda_m0
     break;
   case 4:
+    GpioPinSetFunction(3, GPIO_PIN_PA6, 9); //i2c4_scl_m0
+    GpioPinSetFunction(3, GPIO_PIN_PA5, 9); //i2c4_sda_m0
     break;
   case 5:
+    GpioPinSetFunction(3, GPIO_PIN_PC7, 9); //i2c5_scl_m0
+    GpioPinSetFunction(3, GPIO_PIN_PD0, 9); //i2c5_sda_m0
+    break;
+  case 6:
+    GpioPinSetFunction(0, GPIO_PIN_PD0, 9); //i2c6_scl_m0
+    GpioPinSetFunction(0, GPIO_PIN_PC7, 9); //i2c6_sda_m0
+    break;
+  case 7:
+    GpioPinSetFunction(1, GPIO_PIN_PD0, 9); //i2c7_scl_m0
+    GpioPinSetFunction(1, GPIO_PIN_PD1, 9); //i2c7_sda_m0
     break;
   default:
     break;

--- a/edk2-rockchip/Platform/Radxa/ROCK5A/Library/RockchipPlatformLib/RockchipPlatformLib.c
+++ b/edk2-rockchip/Platform/Radxa/ROCK5A/Library/RockchipPlatformLib/RockchipPlatformLib.c
@@ -175,8 +175,8 @@ I2cIomux (
 {
   switch (id) {
   case 0:
-    GpioPinSetFunction(0, GPIO_PIN_PB3, 2); //i2c0_scl_m0
-    GpioPinSetFunction(0, GPIO_PIN_PA6, 2); //i2c0_sda_m0
+    GpioPinSetFunction(0, GPIO_PIN_PD1, 3); //i2c0_scl_m2
+    GpioPinSetFunction(0, GPIO_PIN_PD2, 3); //i2c0_sda_m2
     break;
   case 1:
     GpioPinSetFunction(0, GPIO_PIN_PB5, 9); //i2c1_scl_m0

--- a/edk2-rockchip/Platform/Radxa/ROCK5B/Library/RockchipPlatformLib/RockchipPlatformLib.c
+++ b/edk2-rockchip/Platform/Radxa/ROCK5B/Library/RockchipPlatformLib/RockchipPlatformLib.c
@@ -173,20 +173,14 @@ I2cIomux (
     GpioPinSetFunction(0, GPIO_PIN_PD5, 9); //i2c1_sda_m2
     break;
   case 2:
-    GpioPinSetFunction(0, GPIO_PIN_PB7, 9); //i2c2_scl_m0
-    GpioPinSetFunction(0, GPIO_PIN_PC0, 9); //i2c2_sda_m0
     break;
   case 3:
-    GpioPinSetFunction(1, GPIO_PIN_PC1, 9); //i2c3_scl_m0
-    GpioPinSetFunction(1, GPIO_PIN_PC0, 9); //i2c3_sda_m0
     break;
   case 4:
     GpioPinSetFunction(2, GPIO_PIN_PB5, 9); //i2c4_scl_m1
     GpioPinSetFunction(2, GPIO_PIN_PB4, 9); //i2c4_sda_m1
     break;
   case 5:
-    GpioPinSetFunction(3, GPIO_PIN_PC7, 9); //i2c5_scl_m0
-    GpioPinSetFunction(3, GPIO_PIN_PD0, 9); //i2c5_sda_m0
     break;
   case 6:
     GpioPinSetFunction(0, GPIO_PIN_PD0, 9); //i2c6_scl_m0

--- a/edk2-rockchip/Platform/Radxa/ROCK5B/Library/RockchipPlatformLib/RockchipPlatformLib.c
+++ b/edk2-rockchip/Platform/Radxa/ROCK5B/Library/RockchipPlatformLib/RockchipPlatformLib.c
@@ -165,12 +165,12 @@ I2cIomux (
 {
   switch (id) {
   case 0:
-    GpioPinSetFunction(0, GPIO_PIN_PB3, 2); //i2c0_scl_m0
-    GpioPinSetFunction(0, GPIO_PIN_PA6, 2); //i2c0_sda_m0
+    GpioPinSetFunction(0, GPIO_PIN_PD1, 3); //i2c0_scl_m2
+    GpioPinSetFunction(0, GPIO_PIN_PD2, 3); //i2c0_sda_m2
     break;
   case 1:
-    GpioPinSetFunction(0, GPIO_PIN_PB5, 9); //i2c1_scl_m0
-    GpioPinSetFunction(0, GPIO_PIN_PB6, 9); //i2c1_sda_m0
+    GpioPinSetFunction(0, GPIO_PIN_PD4, 9); //i2c1_scl_m2
+    GpioPinSetFunction(0, GPIO_PIN_PD5, 9); //i2c1_sda_m2
     break;
   case 2:
     GpioPinSetFunction(0, GPIO_PIN_PB7, 9); //i2c2_scl_m0
@@ -181,8 +181,8 @@ I2cIomux (
     GpioPinSetFunction(1, GPIO_PIN_PC0, 9); //i2c3_sda_m0
     break;
   case 4:
-    GpioPinSetFunction(3, GPIO_PIN_PA6, 9); //i2c4_scl_m0
-    GpioPinSetFunction(3, GPIO_PIN_PA5, 9); //i2c4_sda_m0
+    GpioPinSetFunction(2, GPIO_PIN_PB5, 9); //i2c4_scl_m1
+    GpioPinSetFunction(2, GPIO_PIN_PB4, 9); //i2c4_sda_m1
     break;
   case 5:
     GpioPinSetFunction(3, GPIO_PIN_PC7, 9); //i2c5_scl_m0

--- a/edk2-rockchip/Platform/Radxa/ROCK5B/Library/RockchipPlatformLib/RockchipPlatformLib.c
+++ b/edk2-rockchip/Platform/Radxa/ROCK5B/Library/RockchipPlatformLib/RockchipPlatformLib.c
@@ -165,34 +165,36 @@ I2cIomux (
 {
   switch (id) {
   case 0:
-    /* io mux M2 */
-    PMU2_IOC->GPIO0D_IOMUX_SEL_L = (0x0F00UL << 16) | 0x0300;
-    PMU2_IOC->GPIO0D_IOMUX_SEL_L = (0x00F0UL << 16) | 0x0030;
+    GpioPinSetFunction(0, GPIO_PIN_PB3, 2); //i2c0_scl_m0
+    GpioPinSetFunction(0, GPIO_PIN_PA6, 2); //i2c0_sda_m0
     break;
   case 1:
-    /* io mux */
-    //BUS_IOC->GPIO0B_IOMUX_SEL_H = (0x0FF0UL << 16) | 0x0990;
-    //PMU2_IOC->GPIO0B_IOMUX_SEL_H = (0x0FF0UL << 16) | 0x0880;
+    GpioPinSetFunction(0, GPIO_PIN_PB5, 9); //i2c1_scl_m0
+    GpioPinSetFunction(0, GPIO_PIN_PB6, 9); //i2c1_sda_m0
     break;
   case 2:
-    /* io mux */
-    BUS_IOC->GPIO0B_IOMUX_SEL_H = (0xF000UL << 16) | 0x9000;
-    BUS_IOC->GPIO0C_IOMUX_SEL_L = (0x000FUL << 16) | 0x0009;
-    PMU2_IOC->GPIO0B_IOMUX_SEL_H = (0xF000UL << 16) | 0x8000;
-    PMU2_IOC->GPIO0C_IOMUX_SEL_L = (0x000FUL << 16) | 0x0008;
+    GpioPinSetFunction(0, GPIO_PIN_PB7, 9); //i2c2_scl_m0
+    GpioPinSetFunction(0, GPIO_PIN_PC0, 9); //i2c2_sda_m0
     break;
   case 3:
+    GpioPinSetFunction(1, GPIO_PIN_PC1, 9); //i2c3_scl_m0
+    GpioPinSetFunction(1, GPIO_PIN_PC0, 9); //i2c3_sda_m0
     break;
   case 4:
+    GpioPinSetFunction(3, GPIO_PIN_PA6, 9); //i2c4_scl_m0
+    GpioPinSetFunction(3, GPIO_PIN_PA5, 9); //i2c4_sda_m0
     break;
   case 5:
+    GpioPinSetFunction(3, GPIO_PIN_PC7, 9); //i2c5_scl_m0
+    GpioPinSetFunction(3, GPIO_PIN_PD0, 9); //i2c5_sda_m0
     break;
   case 6:
-    /* io mux M0 */
-    BUS_IOC->GPIO0C_IOMUX_SEL_H = (0xF000UL << 16) | 0x9000;
-    BUS_IOC->GPIO0D_IOMUX_SEL_L = (0x000FUL << 16) | 0x0009;
-    PMU2_IOC->GPIO0C_IOMUX_SEL_H = (0xF000UL << 16) | 0x8000;
-    PMU2_IOC->GPIO0D_IOMUX_SEL_L = (0x000FUL << 16) | 0x0008;
+    GpioPinSetFunction(0, GPIO_PIN_PD0, 9); //i2c6_scl_m0
+    GpioPinSetFunction(0, GPIO_PIN_PC7, 9); //i2c6_sda_m0
+    break;
+  case 7:
+    GpioPinSetFunction(1, GPIO_PIN_PD0, 9); //i2c7_scl_m0
+    GpioPinSetFunction(1, GPIO_PIN_PD1, 9); //i2c7_sda_m0
     break;
   default:
     break;


### PR DESCRIPTION
Refactor I2cIoMux to use GpioPinSetFunction and add missing controllers

Used https://github.com/Joshua-Riek/linux-rockchip/blob/linux-5.10-gen-rkr6/arch/arm64/boot/dts/rockchip/rk3588s-pinctrl.dtsi#L807 as reference