### PR TITLE
支持PCIE 3 PHY拆分配置 / Support PCIe 3 PHY bifurcation

### DIFF
--- a/edk2-rockchip/Silicon/Rockchip/RK3588/Drivers/AcpiPlatformDxe/AcpiPlatformDxe.c
+++ b/edk2-rockchip/Silicon/Rockchip/RK3588/Drivers/AcpiPlatformDxe/AcpiPlatformDxe.c
@@ -122,7 +122,7 @@ AcpiDsdtFixupStatus (
   } DevStatus[] = {
     { "\\_SB.PCI0._STA", FixedPcdGetBool (PcdPcie30Supported) &&
                          PcdGet32 (PcdPcie30State) == PCIE30_STATE_ENABLED },
-    { "\\_SB.PCI1._STA", FALSE }, // not supported yet
+    { "\\_SB.PCI1._STA", FALSE }, // TODO: fix acpi
     { "\\_SB.PCI2._STA", PcdGet32 (PcdComboPhy1Mode) == COMBO_PHY_MODE_PCIE },
     { "\\_SB.PCI3._STA", PcdGet32 (PcdComboPhy2Mode) == COMBO_PHY_MODE_PCIE },
     { "\\_SB.PCI4._STA", PcdGet32 (PcdComboPhy0Mode) == COMBO_PHY_MODE_PCIE },

--- a/edk2-rockchip/Silicon/Rockchip/RK3588/Drivers/AcpiPlatformDxe/AcpiPlatformDxe.c
+++ b/edk2-rockchip/Silicon/Rockchip/RK3588/Drivers/AcpiPlatformDxe/AcpiPlatformDxe.c
@@ -122,7 +122,7 @@ AcpiDsdtFixupStatus (
   } DevStatus[] = {
     { "\\_SB.PCI0._STA", FixedPcdGetBool (PcdPcie30Supported) &&
                          PcdGet32 (PcdPcie30State) == PCIE30_STATE_ENABLED },
-    { "\\_SB.PCI1._STA", FALSE }, // TODO: fix acpi
+    { "\\_SB.PCI1._STA", PcdGet8 (PcdPcie30PhyMode) != PCIE30_PHY_MODE_AGGREGATION },
     { "\\_SB.PCI2._STA", PcdGet32 (PcdComboPhy1Mode) == COMBO_PHY_MODE_PCIE },
     { "\\_SB.PCI3._STA", PcdGet32 (PcdComboPhy2Mode) == COMBO_PHY_MODE_PCIE },
     { "\\_SB.PCI4._STA", PcdGet32 (PcdComboPhy0Mode) == COMBO_PHY_MODE_PCIE },

--- a/edk2-rockchip/Silicon/Rockchip/RK3588/Drivers/AcpiPlatformDxe/AcpiPlatformDxe.inf
+++ b/edk2-rockchip/Silicon/Rockchip/RK3588/Drivers/AcpiPlatformDxe/AcpiPlatformDxe.inf
@@ -55,6 +55,7 @@
   gRK3588TokenSpaceGuid.PcdComboPhy2Mode
   gRK3588TokenSpaceGuid.PcdPcie30Supported
   gRK3588TokenSpaceGuid.PcdPcie30State
+  gRK3588TokenSpaceGuid.PcdPcie30PhyMode
   gRK3588TokenSpaceGuid.PcdPcieEcamCompliantSegmentsMask
   gRockchipTokenSpaceGuid.PcdRkSdmmcBaseAddress
 

--- a/edk2-rockchip/Silicon/Rockchip/RK3588/Drivers/FdtPlatformDxe/FdtPlatformDxe.c
+++ b/edk2-rockchip/Silicon/Rockchip/RK3588/Drivers/FdtPlatformDxe/FdtPlatformDxe.c
@@ -602,6 +602,7 @@ FdtFixupPcie3Devices (
 
   DEBUG ((DEBUG_INFO, "FdtPlatform: Fixing up PCIe 3 devices\n"));
 
+  // TODO: pci2
   FdtEnableNode (Fdt, "/pcie@fe150000",
               PcdGet32 (PcdPcie30State) == PCIE30_STATE_ENABLED);
 }

--- a/edk2-rockchip/Silicon/Rockchip/RK3588/Drivers/FdtPlatformDxe/FdtPlatformDxe.c
+++ b/edk2-rockchip/Silicon/Rockchip/RK3588/Drivers/FdtPlatformDxe/FdtPlatformDxe.c
@@ -602,9 +602,12 @@ FdtFixupPcie3Devices (
 
   DEBUG ((DEBUG_INFO, "FdtPlatform: Fixing up PCIe 3 devices\n"));
 
-  // TODO: pci2
   FdtEnableNode (Fdt, "/pcie@fe150000",
               PcdGet32 (PcdPcie30State) == PCIE30_STATE_ENABLED);
+  if (PcdGet8 (PcdPcie30PhyMode) != PCIE30_PHY_MODE_AGGREGATION) {
+    FdtEnableNode (Fdt, "/pcie@fe160000",
+                PcdGet32 (PcdPcie30State) == PCIE30_STATE_ENABLED);
+  }
 }
 
 STATIC

--- a/edk2-rockchip/Silicon/Rockchip/RK3588/Drivers/FdtPlatformDxe/FdtPlatformDxe.inf
+++ b/edk2-rockchip/Silicon/Rockchip/RK3588/Drivers/FdtPlatformDxe/FdtPlatformDxe.inf
@@ -56,6 +56,7 @@
   gRK3588TokenSpaceGuid.PcdComboPhy2Mode
   gRK3588TokenSpaceGuid.PcdPcie30Supported
   gRK3588TokenSpaceGuid.PcdPcie30State
+  gRK3588TokenSpaceGuid.PcdPcie30PhyMode
 
 [Depex]
   gRockchipPlatformConfigAppliedProtocolGuid

--- a/edk2-rockchip/Silicon/Rockchip/RK3588/Drivers/RK3588Dxe/PciExpress30.c
+++ b/edk2-rockchip/Silicon/Rockchip/RK3588/Drivers/RK3588Dxe/PciExpress30.c
@@ -30,6 +30,7 @@ SetupPcie30Variables (
 {
   UINTN      Size;
   UINT32     Var32;
+  UINT8     Var8;
   EFI_STATUS Status;
 
   Size = sizeof (UINT32);
@@ -39,6 +40,16 @@ SetupPcie30Variables (
                             NULL, &Size, &Var32);
   if (EFI_ERROR (Status) || !FixedPcdGetBool (PcdPcie30Supported)) {
     Status = PcdSet32S (PcdPcie30State, FixedPcdGet32 (PcdPcie30Supported));
+    ASSERT_EFI_ERROR (Status);
+  }
+
+  Size = sizeof (UINT8);
+
+  Status = gRT->GetVariable (L"Pcie30PhyMode",
+                            &gRK3588DxeFormSetGuid,
+                            NULL, &Size, &Var8);
+  if (EFI_ERROR (Status) || !FixedPcdGetBool (PcdPcie30Supported)) {
+    Status = PcdSet8S (PcdPcie30PhyMode, FixedPcdGet8 (PcdPcie30PhyModeDefault));
     ASSERT_EFI_ERROR (Status);
   }
 }

--- a/edk2-rockchip/Silicon/Rockchip/RK3588/Drivers/RK3588Dxe/PciExpress30.c
+++ b/edk2-rockchip/Silicon/Rockchip/RK3588/Drivers/RK3588Dxe/PciExpress30.c
@@ -30,7 +30,8 @@ SetupPcie30Variables (
 {
   UINTN      Size;
   UINT32     Var32;
-  UINT8     Var8;
+  UINT8      Var8;
+
   EFI_STATUS Status;
 
   Size = sizeof (UINT32);

--- a/edk2-rockchip/Silicon/Rockchip/RK3588/Drivers/RK3588Dxe/RK3588Dxe.inf
+++ b/edk2-rockchip/Silicon/Rockchip/RK3588/Drivers/RK3588Dxe/RK3588Dxe.inf
@@ -91,6 +91,8 @@
 
   gRK3588TokenSpaceGuid.PcdPcie30Supported
   gRK3588TokenSpaceGuid.PcdPcie30State
+  gRK3588TokenSpaceGuid.PcdPcie30PhyMode
+  gRK3588TokenSpaceGuid.PcdPcie30PhyModeDefault
 
   gRK3588TokenSpaceGuid.PcdConfigTableMode
   gRK3588TokenSpaceGuid.PcdAcpiPcieEcamCompatModeDefault

--- a/edk2-rockchip/Silicon/Rockchip/RK3588/Drivers/RK3588Dxe/RK3588DxeHii.uni
+++ b/edk2-rockchip/Silicon/Rockchip/RK3588/Drivers/RK3588Dxe/RK3588DxeHii.uni
@@ -122,6 +122,14 @@
 #string STR_PCIE30_STATE_PROMPT                            #language en-US "Support State"
 #string STR_PCIE30_STATE_HELP                              #language en-US "Enable or disable PCIe 3.0 support."
 
+#string STR_PCIE30_PHY_MODE_PROMPT                         #language en-US "PHY Mode"
+#string STR_PCIE30_PHY_MODE_HELP                           #language en-US "Choose PHY Mode\n\nx4:\n    4l -> PCIe3 PHY lane 0123\n    2l -> Not connected\n    1l0 -> Combo PHY #1\n    1l1 -> Combo PHY #2\n    1l2 -> Combo PHY #0\n\nx2 x2:\n    4l -> PCIe3 PHY lane 01\n    2l -> PCIe3 PHY lane 23\n    1l0 -> Combo PHY #1\n    1l1 -> Combo PHY #2\n    1l2 -> Combo PHY #0\n\nx1x1 x2:\n    4l -> PCIe3 PHY lane 0\n    2l -> PCIe3 PHY lane 23\n    1l0 -> PCIe3 PHY lane 1\n    1l1 -> Combo PHY #2\n    1l2 -> Combo PHY #0\n\nx2 x1x1:\n    4l -> PCIe3 PHY lane 01\n    2l -> PCIe3 PHY lane 2\n    1l0 -> Combo PHY #1\n    1l1 -> PCIe3 PHY lane 3\n    1l2 -> Combo PHY #0\n\nx1x1 x1x1:\n    4l -> PCIe3 PHY lane 0\n    2l -> PCIe3 PHY lane 2\n    1l0 -> PCIe3 PHY lane 1\n    1l1 -> PCIe3 PHY lane 3\n    1l2 -> Combo PHY #0\n"
+#string STR_PCIE30_PHY_MODE_AGGREGATION                    #language en-US "x4"
+#string STR_PCIE30_PHY_MODE_NANBNB                         #language en-US "x2 x2"
+#string STR_PCIE30_PHY_MODE_NANBBI                         #language en-US "x1x1 x2"
+#string STR_PCIE30_PHY_MODE_NABINB                         #language en-US "x2 x1x1"
+#string STR_PCIE30_PHY_MODE_NABIBI                         #language en-US "x1x1 x1x1"
+
 /*
  * ACPI / Device Tree configuration
  */

--- a/edk2-rockchip/Silicon/Rockchip/RK3588/Drivers/RK3588Dxe/RK3588DxeHii.vfr
+++ b/edk2-rockchip/Silicon/Rockchip/RK3588/Drivers/RK3588Dxe/RK3588DxeHii.vfr
@@ -122,6 +122,11 @@ formset
       name  = Pcie30State,
       guid  = RK3588DXE_FORMSET_GUID;
 
+    efivarstore PCIE30_PHY_MODE_VARSTORE_DATA,
+      attribute = EFI_VARIABLE_BOOTSERVICE_ACCESS | EFI_VARIABLE_RUNTIME_ACCESS | EFI_VARIABLE_NON_VOLATILE,
+      name  = Pcie30PhyMode,
+      guid  = RK3588DXE_FORMSET_GUID;
+
     efivarstore CONFIG_TABLE_MODE_VARSTORE_DATA,
       attribute = EFI_VARIABLE_BOOTSERVICE_ACCESS | EFI_VARIABLE_RUNTIME_ACCESS | EFI_VARIABLE_NON_VOLATILE,
       name  = ConfigTableMode,
@@ -462,6 +467,19 @@ formset
           default     = PCIE30_STATE_ENABLED,
           option text = STRING_TOKEN(STR_DISABLED), value = PCIE30_STATE_DISABLED, flags = 0;
           option text = STRING_TOKEN(STR_ENABLED), value = PCIE30_STATE_ENABLED, flags = 0;
+        endoneof;
+
+        /* shoule we move this to single PHY settings form */
+        oneof varid = Pcie30PhyMode.Mode,
+          prompt      = STRING_TOKEN(STR_PCIE30_PHY_MODE_PROMPT),
+          help        = STRING_TOKEN(STR_PCIE30_PHY_MODE_HELP),
+          flags       = NUMERIC_SIZE_1 | INTERACTIVE | RESET_REQUIRED,
+          default     = FixedPcdGet8 (PcdPcie30PhyModeDefault),
+          option text = STRING_TOKEN(STR_PCIE30_PHY_MODE_AGGREGATION), value = PCIE30_PHY_MODE_AGGREGATION, flags = 0;
+          option text = STRING_TOKEN(STR_PCIE30_PHY_MODE_NANBNB), value = PCIE30_PHY_MODE_NANBNB, flags = 0;
+          option text = STRING_TOKEN(STR_PCIE30_PHY_MODE_NANBBI), value = PCIE30_PHY_MODE_NANBBI, flags = 0;
+          option text = STRING_TOKEN(STR_PCIE30_PHY_MODE_NABINB), value = PCIE30_PHY_MODE_NABINB, flags = 0;
+          option text = STRING_TOKEN(STR_PCIE30_PHY_MODE_NABIBI), value = PCIE30_PHY_MODE_NABIBI, flags = 0;
         endoneof;
     endform;
 #endif

--- a/edk2-rockchip/Silicon/Rockchip/RK3588/Include/Library/Rk3588Pcie.h
+++ b/edk2-rockchip/Silicon/Rockchip/RK3588/Include/Library/Rk3588Pcie.h
@@ -27,6 +27,10 @@ PciePinmuxInit(
 
 #define NUM_PCIE_CONTROLLER 5
 
+/*
+ * All pcie controllers supports PCIe 3.0
+ * Here we name them using their device tree name in the linux kernel source
+ */
 #define PCIE_SEGMENT_PCIE30X4 0
 #define PCIE_SEGMENT_PCIE30X2 1
 #define PCIE_SEGMENT_PCIE20L0 2

--- a/edk2-rockchip/Silicon/Rockchip/RK3588/Include/VarStoreData.h
+++ b/edk2-rockchip/Silicon/Rockchip/RK3588/Include/VarStoreData.h
@@ -45,6 +45,15 @@ typedef struct {
   UINT32 State;
 } PCIE30_STATE_VARSTORE_DATA;
 
+#define PCIE30_PHY_MODE_AGGREGATION                 4
+#define PCIE30_PHY_MODE_NANBNB                      0
+#define PCIE30_PHY_MODE_NANBBI                      1
+#define PCIE30_PHY_MODE_NABINB                      2
+#define PCIE30_PHY_MODE_NABIBI                      3
+typedef struct {
+  UINT8 Mode;
+} PCIE30_PHY_MODE_VARSTORE_DATA;
+
 #define CONFIG_TABLE_MODE_ACPI                      0x00000001
 #define CONFIG_TABLE_MODE_FDT                       0x00000002
 #define CONFIG_TABLE_MODE_ACPI_FDT                  0x00000003

--- a/edk2-rockchip/Silicon/Rockchip/RK3588/Library/Pcie30PhyLib/Pcie30PhyLib.c
+++ b/edk2-rockchip/Silicon/Rockchip/RK3588/Library/Pcie30PhyLib/Pcie30PhyLib.c
@@ -17,8 +17,7 @@
 #include <Library/TimerLib.h>
 #include <Library/CruLib.h>
 #include <Library/UefiBootServicesTableLib.h>
-
-#define PHY_MODE_PCIE_AGGREGATION           4 // hardcoded for now
+#include <Library/PcdLib.h>
 
 #define PCIE30_PHY_GRF                      0xfd5b8000
 /* PCIEPHY_GRF */
@@ -64,14 +63,15 @@ Pcie30PhyInit (
     // UINTN Retry;
 
     DEBUG ((DEBUG_INFO, "PCIe30: PHY init\n"));
+    DEBUG ((DEBUG_INFO, "PCIe30: PHY mode %d\n", PcdGet8(PcdPcie30PhyMode)));
 
     // MicroSecondDelay(100000);
 
     /* Disable power domain */
     MmioWrite32(0xFD8D8150, 0x1 << 23 | 0x1 << 21); // PD_PCIE & PD_PHP
 
-    /* Phy mode: Aggregation NBNB */
-    MmioWrite32(GRF_PCIE30_PHY_CON(0), (0x7 << 16) | PHY_MODE_PCIE_AGGREGATION);
+    /* Phy mode: from pcd Pcie30PhyMode */
+    MmioWrite32(GRF_PCIE30_PHY_CON(0), (0x7 << 16) | PcdGet8(PcdPcie30PhyMode));
 
     MmioWrite32(0xFD7C8A00, (0x1 << 10) | (0x1 << 26)); 
 

--- a/edk2-rockchip/Silicon/Rockchip/RK3588/Library/Pcie30PhyLib/Pcie30PhyLib.inf
+++ b/edk2-rockchip/Silicon/Rockchip/RK3588/Library/Pcie30PhyLib/Pcie30PhyLib.inf
@@ -35,4 +35,7 @@
 
 [FixedPcd]
 
+[Pcd]
+  gRK3588TokenSpaceGuid.PcdPcie30PhyMode
+
 [Guids]

--- a/edk2-rockchip/Silicon/Rockchip/RK3588/Library/Rk3588PciHostBridgeLib/PciHostBridgeInit.c
+++ b/edk2-rockchip/Silicon/Rockchip/RK3588/Library/Rk3588PciHostBridgeLib/PciHostBridgeInit.c
@@ -98,29 +98,29 @@ IsPcieNumEnabled(
   BOOLEAN Enabled = FALSE;
   switch (PcieNum)
   {
-	/* No bifurcation config yet */
-	case PCIE_SEGMENT_PCIE30X4:
-		Enabled = (FixedPcdGetBool (PcdPcie30Supported) && PcdGet32 (PcdPcie30State) == PCIE30_STATE_ENABLED);
-		break;
+  /* No bifurcation config yet */
+  case PCIE_SEGMENT_PCIE30X4:
+    Enabled = (FixedPcdGetBool (PcdPcie30Supported) && PcdGet32 (PcdPcie30State) == PCIE30_STATE_ENABLED);
+    break;
 
-	case PCIE_SEGMENT_PCIE30X2:
-		Enabled = FALSE;
-		break;
+  case PCIE_SEGMENT_PCIE30X2:
+    Enabled = FALSE;
+    break;
 
-	case PCIE_SEGMENT_PCIE20L0:
-		Enabled = (PcdGet32(PcdComboPhy1Mode) == COMBO_PHY_MODE_PCIE);
-		break;
+  case PCIE_SEGMENT_PCIE20L0:
+    Enabled = (PcdGet32(PcdComboPhy1Mode) == COMBO_PHY_MODE_PCIE);
+    break;
 
-	case PCIE_SEGMENT_PCIE20L1:
-		Enabled = (PcdGet32(PcdComboPhy2Mode) == COMBO_PHY_MODE_PCIE);
-		break;
+  case PCIE_SEGMENT_PCIE20L1:
+    Enabled = (PcdGet32(PcdComboPhy2Mode) == COMBO_PHY_MODE_PCIE);
+    break;
 
-	case PCIE_SEGMENT_PCIE20L2:
-		Enabled = (PcdGet32(PcdComboPhy0Mode) == COMBO_PHY_MODE_PCIE);
-		break;
+  case PCIE_SEGMENT_PCIE20L2:
+    Enabled = (PcdGet32(PcdComboPhy0Mode) == COMBO_PHY_MODE_PCIE);
+    break;
 
-	default:
-	  break;
+  default:
+    break;
   }
 
   return Enabled;
@@ -213,50 +213,50 @@ PciSetupClocks (
   )
 {
   MmioWrite32(0xFD7C8800, (0x1 << 17)|(0x1 << 25));  // pclk_phptop_cru_en
-	MmioWrite32(0xFD7C0880, 0xffff0000);  //CRU_GATE_CON32
-	switch(Segment) {
-		case PCIE_SEGMENT_PCIE30X4:
-			MmioWrite32(0xFD7C8A00, (0x1 << 24)|(0x1 << 26)); //PHPTOPCRU_SOFTRST_CON00
+  MmioWrite32(0xFD7C0880, 0xffff0000);  //CRU_GATE_CON32
+  switch(Segment) {
+    case PCIE_SEGMENT_PCIE30X4:
+      MmioWrite32(0xFD7C8A00, (0x1 << 24)|(0x1 << 26)); //PHPTOPCRU_SOFTRST_CON00
       MmioWrite32(0xFD7C8800, (0x1 << 24));  //PHPTOPCRU_GATE_CON00
       MmioWrite32(0xFD7C0A80, (0x1 << 29));  //CRU_SOFTRST_CON32:resetn_pcie_4l_power_up
       MmioWrite32(0xFD7C089c, (0x1 << 16));  //CRU_GATE_CON39:clk_pcie_4l_pipe_en
-	    MmioWrite32(0xFD7C0888, (0x1 << 17));  //CRU_GATE_CON34:clk_pcie_4l_aux_en
-	    MmioWrite32(0xFD7C0884, (0x1 << 28)|(0x1 << 23)|(0x1 << 18));  //CRU_GATE_CON33:pclk_pcie_4l_en,aclk_pcie_4l_slv_en,aclk_pcie_4l_mstr_en
-			break;
-		case PCIE_SEGMENT_PCIE20L2: //phy0
-			MmioWrite32(0xFD7C8A00, (0x1 << 21)|(0x1 << 18)); //PHPTOPCRU_SOFTRST_CON00
+      MmioWrite32(0xFD7C0888, (0x1 << 17));  //CRU_GATE_CON34:clk_pcie_4l_aux_en
+      MmioWrite32(0xFD7C0884, (0x1 << 28)|(0x1 << 23)|(0x1 << 18));  //CRU_GATE_CON33:pclk_pcie_4l_en,aclk_pcie_4l_slv_en,aclk_pcie_4l_mstr_en
+      break;
+    case PCIE_SEGMENT_PCIE20L2: //phy0
+      MmioWrite32(0xFD7C8A00, (0x1 << 21)|(0x1 << 18)); //PHPTOPCRU_SOFTRST_CON00
       MmioWrite32(0xFD7C8800, (0x1 << 21)|(0x1 << 18));  //PHPTOPCRU_GATE_CON00
       MmioWrite32(0xFD7C0A84, (0x1 << 17));  //CRU_SOFTRST_CON33:resetn_pcie_1l2_power_up
-	    MmioWrite32(0xFD7C0898, (0x1 << 29));  //CRU_GATE_CON38:clk_pcie_1l2_pipe_en
-	    MmioWrite32(0xFD7C0888, (0x1 << 21)|(0x1 << 16));  //CRU_GATE_CON34:clk_pcie_1l2_aux_en,pclk_pcie_1l2_en
-	    MmioWrite32(0xFD7C0884, (0x1 << 27)|(0x1 << 22));  //CRU_GATE_CON33:aclk_pcie_1l2_slv_en,aclk_pcie_1l2_mstr_en
-			break;
-		case PCIE_SEGMENT_PCIE20L0: //phy1
-			MmioWrite32(0xFD7C8A00, (0x1 << 22)|(0x1 << 19)); //PHPTOPCRU_SOFTRST_CON00
+      MmioWrite32(0xFD7C0898, (0x1 << 29));  //CRU_GATE_CON38:clk_pcie_1l2_pipe_en
+      MmioWrite32(0xFD7C0888, (0x1 << 21)|(0x1 << 16));  //CRU_GATE_CON34:clk_pcie_1l2_aux_en,pclk_pcie_1l2_en
+      MmioWrite32(0xFD7C0884, (0x1 << 27)|(0x1 << 22));  //CRU_GATE_CON33:aclk_pcie_1l2_slv_en,aclk_pcie_1l2_mstr_en
+      break;
+    case PCIE_SEGMENT_PCIE20L0: //phy1
+      MmioWrite32(0xFD7C8A00, (0x1 << 22)|(0x1 << 19)); //PHPTOPCRU_SOFTRST_CON00
       MmioWrite32(0xFD7C8800, (0x1 << 22)|(0x1 << 19));  //PHPTOPCRU_GATE_CON00
       MmioWrite32(0xFD7C0A80, (0x1 << 31));  //CRU_SOFTRST_CON32:resetn_pcie_1l0_power_up
-	    MmioWrite32(0xFD7C0898, (0x1 << 30));  //CRU_GATE_CON38:clk_pcie_1l0_pipe_en
-	    MmioWrite32(0xFD7C0888, (0x1 << 19));  //CRU_GATE_CON34:clk_pcie_1l0_aux_en
-	    MmioWrite32(0xFD7C0884, (0x1 << 30)|(0x1 << 25)|(0x1 << 20));  //CRU_GATE_CON33:pclk_pcie_1l0_en,aclk_pcie_1l0_slv_en,aclk_pcie_1l0_mstr_en
-			break;
-		case PCIE_SEGMENT_PCIE20L1: //phy2
-			MmioWrite32(0xFD7C8A00, (0x1 << 23)|(0x1 << 20)); //PHPTOPCRU_SOFTRST_CON00
+      MmioWrite32(0xFD7C0898, (0x1 << 30));  //CRU_GATE_CON38:clk_pcie_1l0_pipe_en
+      MmioWrite32(0xFD7C0888, (0x1 << 19));  //CRU_GATE_CON34:clk_pcie_1l0_aux_en
+      MmioWrite32(0xFD7C0884, (0x1 << 30)|(0x1 << 25)|(0x1 << 20));  //CRU_GATE_CON33:pclk_pcie_1l0_en,aclk_pcie_1l0_slv_en,aclk_pcie_1l0_mstr_en
+      break;
+    case PCIE_SEGMENT_PCIE20L1: //phy2
+      MmioWrite32(0xFD7C8A00, (0x1 << 23)|(0x1 << 20)); //PHPTOPCRU_SOFTRST_CON00
       MmioWrite32(0xFD7C8800, (0x1 << 23)|(0x1 << 20));  //PHPTOPCRU_GATE_CON00
       MmioWrite32(0xFD7C0A84, (0x1 << 16));  //CRU_SOFTRST_CON33:resetn_pcie_1l1_power_up
-	    MmioWrite32(0xFD7C0898, (0x1 << 31));  //CRU_GATE_CON38:clk_pcie_1l1_pipe_en
-	    MmioWrite32(0xFD7C0888, (0x1 << 20));  //CRU_GATE_CON34:clk_pcie_1l1_aux_en
-	    MmioWrite32(0xFD7C0884, (0x1 << 31)|(0x1 << 26)|(0x1 << 21));  //CRU_GATE_CON33:pclk_pcie_1l1_en,aclk_pcie_1l1_slv_en,aclk_pcie_1l1_mstr_en
-			break;
+      MmioWrite32(0xFD7C0898, (0x1 << 31));  //CRU_GATE_CON38:clk_pcie_1l1_pipe_en
+      MmioWrite32(0xFD7C0888, (0x1 << 20));  //CRU_GATE_CON34:clk_pcie_1l1_aux_en
+      MmioWrite32(0xFD7C0884, (0x1 << 31)|(0x1 << 26)|(0x1 << 21));  //CRU_GATE_CON33:pclk_pcie_1l1_en,aclk_pcie_1l1_slv_en,aclk_pcie_1l1_mstr_en
+      break;
 
-		case PCIE_SEGMENT_PCIE30X2:
+    case PCIE_SEGMENT_PCIE30X2:
       MmioWrite32(0xFD7C0A80, (0x1 << 30));  //CRU_SOFTRST_CON32:resetn_pcie_2l_power_up
       MmioWrite32(0xFD7C089c, (0x1 << 17));  //CRU_GATE_CON39:clk_pcie_2l_pipe_en
-	    MmioWrite32(0xFD7C0888, (0x1 << 18));  //CRU_GATE_CON34:clk_pcie_2l_aux_en
-	    MmioWrite32(0xFD7C0884, (0x1 << 29)|(0x1 << 24)|(0x1 << 19));  //CRU_GATE_CON33:pclk_pcie_2l_en,aclk_pcie_2l_slv_en,aclk_pcie_2l_mstr_en
+      MmioWrite32(0xFD7C0888, (0x1 << 18));  //CRU_GATE_CON34:clk_pcie_2l_aux_en
+      MmioWrite32(0xFD7C0884, (0x1 << 29)|(0x1 << 24)|(0x1 << 19));  //CRU_GATE_CON33:pclk_pcie_2l_en,aclk_pcie_2l_slv_en,aclk_pcie_2l_mstr_en
       break;
-		default:
-			break;
-	}
+    default:
+      break;
+  }
 
 }
 

--- a/edk2-rockchip/Silicon/Rockchip/RK3588/Library/Rk3588PciHostBridgeLib/Rk3588PciHostBridgeLib.inf
+++ b/edk2-rockchip/Silicon/Rockchip/RK3588/Library/Rk3588PciHostBridgeLib/Rk3588PciHostBridgeLib.inf
@@ -51,5 +51,6 @@
   gRK3588TokenSpaceGuid.PcdComboPhy2Mode
 
   gRK3588TokenSpaceGuid.PcdPcie30State
+  gRK3588TokenSpaceGuid.PcdPcie30PhyMode
 
   gRK3588TokenSpaceGuid.PcdPcieEcamCompliantSegmentsMask

--- a/edk2-rockchip/Silicon/Rockchip/RK3588/RK3588.dec
+++ b/edk2-rockchip/Silicon/Rockchip/RK3588/RK3588.dec
@@ -42,6 +42,7 @@
   gRK3588TokenSpaceGuid.PcdComboPhy2ModeDefault|0|UINT32|0x00010106
 
   gRK3588TokenSpaceGuid.PcdPcie30Supported|FALSE|BOOLEAN|0x00010201
+  gRK3588TokenSpaceGuid.PcdPcie30PhyModeDefault|4|UINT8|0x00010202
 
   gRK3588TokenSpaceGuid.PcdAcpiPcieEcamCompatModeDefault|0|UINT32|0x00010301
 
@@ -81,6 +82,7 @@
   gRK3588TokenSpaceGuid.PcdComboPhy2Mode|0|UINT32|0x00000103
 
   gRK3588TokenSpaceGuid.PcdPcie30State|0|UINT32|0x00000201
+  gRK3588TokenSpaceGuid.PcdPcie30PhyMode|0|UINT8|0x00000202
 
   gRK3588TokenSpaceGuid.PcdConfigTableMode|0|UINT32|0x00000300
   gRK3588TokenSpaceGuid.PcdAcpiPcieEcamCompatMode|0|UINT32|0x00000301

--- a/edk2-rockchip/Silicon/Rockchip/RK3588/RK3588Base.dsc.inc
+++ b/edk2-rockchip/Silicon/Rockchip/RK3588/RK3588Base.dsc.inc
@@ -256,6 +256,7 @@
   # PCI Express 3.0 support flags and default values
   #
   gRK3588TokenSpaceGuid.PcdPcie30Supported|FALSE
+  gRK3588TokenSpaceGuid.PcdPcie30PhyModeDefault|4 # AGGREGATION
 
   #
   # ACPI support flags and default values
@@ -302,6 +303,7 @@
   # PCI Express 3.0
   #
   gRK3588TokenSpaceGuid.PcdPcie30State|L"Pcie30State"|gRK3588DxeFormSetGuid|0x0|gRK3588TokenSpaceGuid.PcdPcie30Supported
+  gRK3588TokenSpaceGuid.PcdPcie30PhyMode|L"Pcie30PhyMode"|gRK3588DxeFormSetGuid|0x0|4 # AGGREGATION
 
   #
   # ACPI / Device Tree


### PR DESCRIPTION
`STR_PCIE30_PHY_MODE_HELP`在默认文本mode下显示效果不太行

`PcdPcie30PhyModeDefault`可以改变默认拆分模式

`STR_PCIE30_PHY_MODE_HELP` looks real bad in default text mode

`PcdPcie30PhyModeDefault` controlls default pcie3 phy mode
