### PR TITLE
FriendlyELEC/NanoPC-T6: enable USB 2.0 on LTS board

### DIFF
--- a/edk2-rockchip/Platform/FriendlyElec/NanoPC-T6/Library/RockchipPlatformLib/RockchipPlatformLib.c
+++ b/edk2-rockchip/Platform/FriendlyElec/NanoPC-T6/Library/RockchipPlatformLib/RockchipPlatformLib.c
@@ -211,6 +211,9 @@ UsbPortPowerEnable (
   GpioPinWrite (1, GPIO_PIN_PD2, TRUE);
   GpioPinSetDirection (1, GPIO_PIN_PD2, GPIO_PIN_OUTPUT);
 
+  /* Set GPIO1 PA4 (USB20_HOST_PWREN) output high to power USB 2.0 ports */
+  GpioPinWrite (1, GPIO_PIN_PA4, TRUE);
+  GpioPinSetDirection (1, GPIO_PIN_PA4, GPIO_PIN_OUTPUT);
   // DEBUG((DEBUG_INFO, "Trying to enable on-board LED1\n"));
   // GpioPinWrite (2, GPIO_PIN_PC0, TRUE);
   // GpioPinSetDirection (2, GPIO_PIN_PC0, GPIO_PIN_OUTPUT);


### PR DESCRIPTION
NanoPC-T6 LTS has different USB configuration. There is no minipcie slot, two usb 2.0 ports are accessible from outside and another two on internal header.

To have it working we need to enable USB20_HOST_PWREN line.

Closes: #153