### PR TITLE
doc: update Install required packages for Debian

### DIFF
--- a/README.md
+++ b/README.md
@@ -306,7 +306,7 @@ The firmware can only be built on Linux currently. For Windows use WSL.
 
    For Ubuntu/Debian:
    ```bash
-   sudo apt install git gcc g++ build-essential gcc-aarch64-linux-gnu iasl python3-pyelftools uuid-dev python-is-python3 device-tree-compiler
+   sudo apt install git gcc g++ build-essential gcc-aarch64-linux-gnu acpica-tools python3-pyelftools uuid-dev python-is-python3 device-tree-compiler
    ```
    For Arch Linux:
    ```bash

--- a/README.md
+++ b/README.md
@@ -306,7 +306,7 @@ The firmware can only be built on Linux currently. For Windows use WSL.
 
    For Ubuntu/Debian:
    ```bash
-   sudo apt install git gcc g++ build-essential gcc-aarch64-linux-gnu iasl python3-pyelftools uuid-dev
+   sudo apt install git gcc g++ build-essential gcc-aarch64-linux-gnu iasl python3-pyelftools uuid-dev python-is-python3 device-tree-compiler
    ```
    For Arch Linux:
    ```bash


### PR DESCRIPTION
In Debian Trixie this fixes: `/bin/sh: 1: python: not found` and `sh: 1: dtc: not found`