### PR TITLE
Rockchip/StatusLedDxe: Enable PCA expander-backed Status LED

### DIFF
--- a/edk2-rockchip/Silicon/Rockchip/Drivers/StatusLedDxe/StatusLedDxe.c
+++ b/edk2-rockchip/Silicon/Rockchip/Drivers/StatusLedDxe/StatusLedDxe.c
@@ -231,7 +231,7 @@ NotifyPlatformBmAfterConsole (
 STATIC
 VOID
 EFIAPI
-NotifyExitBootServices (
+NotifyBeforeExitBootServices (
   IN EFI_EVENT  Event,
   IN VOID       *Context
   )
@@ -256,7 +256,7 @@ StatusLedDxeInitialize (
 
   Status = gBS->CreateEvent (
                   EVT_TIMER | EVT_NOTIFY_SIGNAL,  // Type
-                  TPL_NOTIFY,                     // NotifyTpl
+                  TPL_CALLBACK,                   // NotifyTpl
                   TimerHandler,                   // NotifyFunction
                   NULL,                           // NotifyContext
                   &mTimerEvent                    // Event
@@ -270,7 +270,7 @@ StatusLedDxeInitialize (
 
   Status = gBS->CreateEventEx (
                   EVT_NOTIFY_SIGNAL,                            // Type
-                  TPL_NOTIFY,                                   // NotifyTpl
+                  TPL_CALLBACK,                                 // NotifyTpl
                   NotifyPlatformBmAfterConsole,                 // NotifyFunction
                   NULL,                                         // NotifyContext
                   &gRockchipEventPlatformBmAfterConsoleGuid,    // EventGroup
@@ -278,12 +278,12 @@ StatusLedDxeInitialize (
                   );
 
   Status = gBS->CreateEventEx (
-                  EVT_NOTIFY_SIGNAL,                // Type
-                  TPL_NOTIFY,                       // NotifyTpl
-                  NotifyExitBootServices,           // NotifyFunction
-                  NULL,                             // NotifyContext
-                  &gEfiEventExitBootServicesGuid,   // EventGroup
-                  &Event                            // Event
+                  EVT_NOTIFY_SIGNAL,                      // Type
+                  TPL_CALLBACK,                           // NotifyTpl
+                  NotifyBeforeExitBootServices,           // NotifyFunction
+                  NULL,                                   // NotifyContext
+                  &gEfiEventBeforeExitBootServicesGuid,   // EventGroup
+                  &Event                                  // Event
                   );
 
   return EFI_SUCCESS;

--- a/edk2-rockchip/Silicon/Rockchip/Drivers/StatusLedDxe/StatusLedDxe.inf
+++ b/edk2-rockchip/Silicon/Rockchip/Drivers/StatusLedDxe/StatusLedDxe.inf
@@ -34,7 +34,7 @@
 [Protocols]
 
 [Guids]
-  gEfiEventExitBootServicesGuid
+  gEfiEventBeforeExitBootServicesGuid
   gRockchipEventPlatformBmAfterConsoleGuid
 
 [Depex]


### PR DESCRIPTION
Extend the StatusLed DXE driver to reliably drive LEDs connected through I²C PCA expanders, not just direct GPIOs.

- Switch event callbacks from TPL_NOTIFY to TPL_CALLBACK to align with the I²C driver’s working with TPL < TPL_NOTIFY.
- Move the final LED state update from ExitBootServices to BeforeExitBootServices, ensuring the last I²C transaction completes before Boot Services are torn down.

This ensures reliable control of status LEDs via PCA expander GPIO pins without priority conflicts.