### PR TITLE
feat: ensure ethernet macs get populated in device trees

### DIFF
--- a/edk2-rockchip/Silicon/Rockchip/Include/Library/OtpLib.h
+++ b/edk2-rockchip/Silicon/Rockchip/Include/Library/OtpLib.h
@@ -32,4 +32,9 @@ OtpReadCpuVersion (
   OUT UINT8  *Version
   );
 
+VOID
+OtpGetGmacMacAddress (
+  OUT EFI_MAC_ADDRESS  *MacAddress
+  );
+
 #endif /* OTPLIB_H__ */

--- a/edk2-rockchip/Silicon/Rockchip/RK3588/Drivers/FdtPlatformDxe/FdtPlatformDxe.c
+++ b/edk2-rockchip/Silicon/Rockchip/RK3588/Drivers/FdtPlatformDxe/FdtPlatformDxe.c
@@ -18,6 +18,8 @@
 #include <Library/DxeServicesLib.h>
 #include <Library/FdtLib.h>
 #include <Library/MemoryAllocationLib.h>
+#include <Library/NetLib.h>
+#include <Library/OtpLib.h>
 #include <Library/PrintLib.h>
 #include <Library/Rk3588Pcie.h>
 #include <Library/RockchipPlatformLib.h>
@@ -932,6 +934,59 @@ FdtPlatformBuildOverridePaths (
 }
 
 STATIC
+VOID
+EFIAPI
+FdtFixupGmacMacAddress (
+  IN VOID  **Fdt
+  )
+{
+  EFI_MAC_ADDRESS  MacAddress;
+  INT32            Node;
+  INT32            Ret;
+  EFI_MAC_ADDRESS  MacAddressCopy;
+  CONST struct {
+    CONST CHAR8  *NodePath;
+    UINT8        Increment;
+  } GmacNodes[] = {
+    { "/ethernet@fe1b0000", 0 },
+    { "/ethernet@fe1c0000", 1 },
+    { NULL,                 0 }
+  };
+  UINTN  Index;
+
+  DEBUG((DEBUG_INFO, "FdtPlatform: Fixing up GMAC MAC address\n"));
+
+  // Retrieve MAC address from OTP
+  OtpGetGmacMacAddress(&MacAddress);
+
+  // Iterate over GMAC nodes
+  for (Index = 0; GmacNodes[Index].NodePath != NULL; Index++) {
+    MacAddressCopy = MacAddress;
+    MacAddressCopy.Addr[5] += GmacNodes[Index].Increment;
+
+    Node = FdtPathOffset (*Fdt, GmacNodes[Index].NodePath);
+    if (Node < 0) {
+      DEBUG((DEBUG_WARN, "FdtPlatform: Couldn't locate FDT node '%a'. Ret=%a\n",
+             GmacNodes[Index].NodePath, FdtStrerror (Node)));
+      continue;
+    }
+
+    // Set the mac-address property (6 bytes)
+    Ret = FdtSetProp (*Fdt, Node, "mac-address", &MacAddressCopy.Addr, NET_ETHER_ADDR_LEN);
+    if (Ret < 0) {
+      DEBUG((DEBUG_ERROR, "FdtPlatform: Failed to set 'mac-address' for '%a'. Ret=%a\n",
+             GmacNodes[Index].NodePath, FdtStrerror (Ret)));     
+      continue;
+    }
+
+    DEBUG((DEBUG_INFO, "FdtPlatform: Set MAC address %02x:%02x:%02x:%02x:%02x:%02x for '%a'\n",
+           MacAddressCopy.Addr[0], MacAddressCopy.Addr[1], MacAddressCopy.Addr[2],
+           MacAddressCopy.Addr[3], MacAddressCopy.Addr[4], MacAddressCopy.Addr[5],
+           GmacNodes[Index].NodePath));
+  }
+}
+
+STATIC
 EFI_STATUS
 EFIAPI
 FdtPlatformProcessFileSystem (
@@ -1012,6 +1067,11 @@ FdtPlatformProcessFileSystem (
       Status = EFI_SUCCESS;
     }
   }
+
+  //
+  // Patch the FDT with our Mac Address
+  //
+  FdtFixupGmacMacAddress (&NewFdt);
 
   //
   // Use the new FDT if it overrides the platform default and/or has
@@ -1391,6 +1451,7 @@ FdtPlatformDxeInitialize (
   }
 
   ApplyPlatformFdtFixups (&mPlatformFdt);
+  FdtFixupGmacMacAddress (&mPlatformFdt);
 
   Status = gBS->InstallConfigurationTable (&gFdtTableGuid, mPlatformFdt);
   if (EFI_ERROR (Status)) {

--- a/edk2-rockchip/Silicon/Rockchip/RK3588/Drivers/FdtPlatformDxe/FdtPlatformDxe.inf
+++ b/edk2-rockchip/Silicon/Rockchip/RK3588/Drivers/FdtPlatformDxe/FdtPlatformDxe.inf
@@ -20,9 +20,11 @@
   FdtPlatformDxe.c
 
 [Packages]
+  CryptoPkg/CryptoPkg.dec
   EmbeddedPkg/EmbeddedPkg.dec
   MdePkg/MdePkg.dec
   MdeModulePkg/MdeModulePkg.dec
+  NetworkPkg/NetworkPkg.dec
   Silicon/Rockchip/RockchipPkg.dec
   Silicon/Rockchip/RK3588/RK3588.dec
 
@@ -34,6 +36,7 @@
   DxeServicesLib
   FdtLib
   MemoryAllocationLib
+  OtpLib
   PrintLib
   RockchipPlatformLib
   UefiBootServicesTableLib

--- a/edk2-rockchip/Silicon/Rockchip/RK3588/Drivers/GmacPlatformDxe/GmacPlatformDxe.c
+++ b/edk2-rockchip/Silicon/Rockchip/RK3588/Drivers/GmacPlatformDxe/GmacPlatformDxe.c
@@ -429,31 +429,6 @@ GmacPlatformSetInterfaceSpeed (
   return GmacSetTxClockSpeed (Gmac->Id, TRUE, Speed);
 }
 
-STATIC
-VOID
-GmacGetOtpMacAddress (
-  OUT EFI_MAC_ADDRESS  *MacAddress
-  )
-{
-  UINT8  OtpData[32];
-  UINT8  Hash[SHA256_DIGEST_SIZE];
-
-  /* Generate MAC addresses from the first 32 bytes in the OTP */
-  OtpRead (0x00, sizeof (OtpData), OtpData);
-  Sha256HashAll (OtpData, sizeof (OtpData), Hash);
-
-  /* Clear multicast bit, set locally administered bit. */
-  Hash[0] &= 0xFE;
-  Hash[0] |= 0x02;
-
-  /* ... and for compatibility with old drivers (see https://github.com/jaredmcneill/quartz64_uefi/pull/68) */
-  Hash[3] &= 0xFE;
-  Hash[3] |= 0x02;
-
-  ZeroMem (MacAddress, sizeof (EFI_MAC_ADDRESS));
-  CopyMem (MacAddress, Hash, NET_ETHER_ADDR_LEN);
-}
-
 EFI_STATUS
 EFIAPI
 GmacPlatformDxeInitialize (
@@ -467,7 +442,7 @@ GmacPlatformDxeInitialize (
   GMAC_DEVICE      *Gmac;
   EFI_HANDLE       Handle;
 
-  GmacGetOtpMacAddress (&MacAddress);
+  OtpGetGmacMacAddress (&MacAddress);
 
   for (Index = 0; Index < ARRAY_SIZE (mGmacDevices); Index++) {
     Gmac = &mGmacDevices[Index];

--- a/edk2-rockchip/Silicon/Rockchip/RK3588/Library/OtpLib/OtpLib.inf
+++ b/edk2-rockchip/Silicon/Rockchip/RK3588/Library/OtpLib/OtpLib.inf
@@ -22,14 +22,18 @@
 
 [Packages]
   ArmPkg/ArmPkg.dec
+  CryptoPkg/CryptoPkg.dec
   MdePkg/MdePkg.dec
+  NetworkPkg/NetworkPkg.dec
   EmbeddedPkg/EmbeddedPkg.dec
   Silicon/Rockchip/RK3588/RK3588.dec
 
 [LibraryClasses]
   BaseLib
+  BaseCryptLib
   DebugLib
   IoLib
+  NetLib
   TimerLib
 
 [Guids]


### PR DESCRIPTION
If we are in device tree mode, we should update it so MACs from the bootloader pass through to the running system. Without this, PXE services such as MAAS fail to identify nodes. This also mimics how u-boot patches MACs into device trees.