### PR TITLE
Silicon/RK3588: Fix combo PHY to PCIe controller lane-select mapping

### DIFF
--- a/edk2-rockchip/Silicon/Rockchip/RK3588/Drivers/RK3588Dxe/ComboPhy.c
+++ b/edk2-rockchip/Silicon/Rockchip/RK3588/Drivers/RK3588Dxe/ComboPhy.c
@@ -70,12 +70,13 @@ InitComPhyConfig (
       MmioWrite32 (PhyBaseAddr + (0xb << 2), 0x47);
       MmioWrite32 (PhyBaseAddr + (0xd << 2), 0x57);
 
-      if (PhyBaseAddr == COMBO_PIPE_PHY0) {
-        MmioWrite32 (PHP_GRF_BASE + PHP_GRF_PCIESEL_CON, BIT1 << 16);
-      }
-
+      /* PHY0 feeds pcie2x1l2, which has no lane-select bit. */
       if (PhyBaseAddr == COMBO_PIPE_PHY1) {
         MmioWrite32 (PHP_GRF_BASE + PHP_GRF_PCIESEL_CON, BIT0 << 16);
+      }
+
+      if (PhyBaseAddr == COMBO_PIPE_PHY2) {
+        MmioWrite32 (PHP_GRF_BASE + PHP_GRF_PCIESEL_CON, BIT1 << 16);
       }
 
       break;


### PR DESCRIPTION
`PHP_GRF_PCIESEL_CON` selects whether `pcie2x1l0` and `pcie2x1l1` are fed by their combo PHY. Per the TRM and `rk3588_combphy_cfg()` in mainline's `phy-rockchip-naneng-combphy.c`:

| Combo PHY | Feeds | Lane select bit |
|---|---|---|
| combphy0 | `pcie2x1l2` | none, no mux |
| combphy1 | `pcie2x1l0` | bit 0 (`pcie1l0_sel`) |
| combphy2 | `pcie2x1l1` | bit 1 (`pcie1l1_sel`) |

`InitComPhyConfig()` is shifted by one. It clears bit 1 for combphy0 and has no case for combphy2, so a board running combphy2 in PCIe mode never gets its lane routed and the controller does not train. The combphy0 branch hid this by clearing bit 1 as a side effect on boards that also run combphy0 in PCIe mode. Introduced by `c206fdfe`.

## Blast radius

Both bits reset to 1 and must be cleared to select the combo PHY. By (`ComboPhy0ModeDefault`, `ComboPhy2ModeDefault`):

* **Unaffected**, both PCIE, bit 1 cleared either way: NanoPC-T6, NanoPi-M6, NanoPi-R6C, NanoPi-R6S, H88K, OrangePi5Plus, ROCK5ITX
* **Unaffected**, neither in PCIe mode: ITX-3588J, R58X, R58-Mini
* **Changed but benign**, PHY0=PCIE with PHY2 not in PCIe mode, so bit 1 was cleared spuriously and now is not: IndiedroidNova, AIO-3588Q, ROC-RK3588S-PC, NanoPC-CM3588-NAS, Edge2, OrangePi5, ROCK5A, ROCK5B, ROCK5BPlus, FydetabDuo
* **Fixed**, PHY0=SATA with PHY2=PCIE: QuartzPro64, and **Mixtile Blade3**, which wires `pcie2x1l1` in `RockchipPlatformLib.c:258`

The benign group is safe because `IsPcieNumEnabled()` gates `PCIE_SEGMENT_PCIE20L1` on `PcdComboPhy2Mode == COMBO_PHY_MODE_PCIE`, leaving the mux target unused. ITX-3588J, R58X and R58-Mini already ship with bit 1 never cleared and their PCIe 3.0 x4 works.

## Testing

Verified on a Pine64 QuartzPro64 (combphy0=SATA, combphy2=PCIe). Segment 3 trains and the onboard RTL8111HS works. `mm 0xFD5B0100 -w 4` reads bit 1 as 1 before and 0 after.

That board port is in progress and will be its own PR. This fix is one of its dependencies.

The table above is derived from DSC defaults and the TRM, not measured. I have not tested any board but my own. A check from a Mixtile Blade3 owner would be welcome.
