### PR TITLE
Silicon/Rockchip: RkFvbDxe: Only use the SPL boot medium for NV storage

### DIFF
--- a/edk2-rockchip/Silicon/Rockchip/Drivers/RkFvbDxe/RkFvbDxe.c
+++ b/edk2-rockchip/Silicon/Rockchip/Drivers/RkFvbDxe/RkFvbDxe.c
@@ -1533,30 +1533,19 @@ FvbFindBootDiskDevice (
   for (DevIndex = 0; DevIndex < ARRAY_SIZE (mFvbSecondaryRkBootDevices); DevIndex++) {
     RkBootDevice = &mFvbSecondaryRkBootDevices[DevIndex];
 
+    /* Firmware on another medium must not claim the variable store. */
+    if ((mBootDeviceType != RkAtagBootDevTypeUnknown) &&
+        (mBootDeviceType != RkBootDevice->AtagBootDevType))
+    {
+      continue;
+    }
+
     for (HandleIndex = 0; HandleIndex < NoHandles; HandleIndex++) {
       Handle = Handles[HandleIndex];
 
       FvbProcessBootDiskDeviceHandle (Handle, RkBootDevice);
 
       if (mFvbDevice->DiskDevice != NULL) {
-        if ((mBootDeviceType != RkAtagBootDevTypeUnknown) &&
-            (mBootDeviceType != RkBootDevice->AtagBootDevType))
-        {
-          DEBUG ((
-            DEBUG_WARN,
-            "%a: WARNING: Found boot device type (0x%x) does not match SPL (0x%x)!\n",
-            __FUNCTION__,
-            RkBootDevice->AtagBootDevType,
-            mBootDeviceType
-            ));
-          DEBUG ((DEBUG_WARN, "%a: WARNING: Variable store might be using the wrong device!\n", __FUNCTION__));
-          DEBUG ((
-            DEBUG_WARN,
-            "%a: WARNING: Consider erasing any firmware present on other devices (SPI/EMMC/SD)!\n",
-            __FUNCTION__
-            ));
-        }
-
         Status = gBS->InstallMultipleProtocolInterfaces (
                         &Handle,
                         &gRockchipFirmwareBootDeviceProtocolGuid,


### PR DESCRIPTION
On boards with no SPI NOR the UEFI variable store lives on the boot medium, found by scanning block devices for a valid FIT at `PcdFitImageFlashAddress`. The candidate list is ordered SD before eMMC, and `FvbFindBootDiskDevice()` took the first medium carrying firmware rather than the one SPL booted from, warning on mismatch but proceeding anyway.

With firmware on eMMC and an SD card that also holds firmware, the variable store therefore bound to the SD card while the firmware ran from eMMC, and no UEFI setting persisted at all.

Skip candidates that do not match `mBootDeviceType`, which makes the mismatch structurally impossible and leaves the three warnings unreachable. An `Unknown` SPL boot device still falls back to scanning everything, and the path runs under `if (!mFvbDevice->IsSpiFlashAvailable)`, so SPI NOR boards never reach it.

## Testing

Verified on a Pine64 QuartzPro64, which has no SPI NOR fitted, so firmware and the variable store both live on eMMC. The board cannot retain any UEFI setting when eMMC and SD are both in use and EDK2 is installed to eMMC, because SD is probed first and claims the variable store. After this change settings persist with the card inserted.

Only tested on my own board. The change is inert unless SPI flash is absent and a second medium also carries firmware. Testing on other boards without SPI NOR that can boot from more than one medium would be welcome.
